### PR TITLE
Disable assert for target build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 sudo: enabled
 
+install:
+  - sudo apt-get install lcov
+
 before_script:
   - cd test && mkdir build && cd build
 

--- a/src/lib/tinycbor/src/cbor.h
+++ b/src/lib/tinycbor/src/cbor.h
@@ -329,7 +329,9 @@ CBOR_INLINE_API bool cbor_value_is_boolean(const CborValue *value)
 { return value->type == CborBooleanType; }
 CBOR_INLINE_API CborError cbor_value_get_boolean(const CborValue *value, bool *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_boolean(value));
+#endif
     *result = !!value->extra;
     return CborNoError;
 }
@@ -339,7 +341,9 @@ CBOR_INLINE_API bool cbor_value_is_simple_type(const CborValue *value)
 { return value->type == CborSimpleType; }
 CBOR_INLINE_API CborError cbor_value_get_simple_type(const CborValue *value, uint8_t *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_simple_type(value));
+#endif
     *result = (uint8_t)value->extra;
     return CborNoError;
 }
@@ -354,21 +358,27 @@ CBOR_INLINE_API bool cbor_value_is_negative_integer(const CborValue *value)
 
 CBOR_INLINE_API CborError cbor_value_get_raw_integer(const CborValue *value, uint64_t *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_integer(value));
+#endif
     *result = _cbor_value_extract_int64_helper(value);
     return CborNoError;
 }
 
 CBOR_INLINE_API CborError cbor_value_get_uint64(const CborValue *value, uint64_t *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_unsigned_integer(value));
+#endif
     *result = _cbor_value_extract_int64_helper(value);
     return CborNoError;
 }
 
 CBOR_INLINE_API CborError cbor_value_get_int64(const CborValue *value, int64_t *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_integer(value));
+#endif
     *result = (int64_t) _cbor_value_extract_int64_helper(value);
     if (value->flags & CborIteratorFlag_NegativeInteger)
         *result = -*result - 1;
@@ -377,7 +387,9 @@ CBOR_INLINE_API CborError cbor_value_get_int64(const CborValue *value, int64_t *
 
 CBOR_INLINE_API CborError cbor_value_get_int(const CborValue *value, int *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_integer(value));
+#endif
     *result = (int) _cbor_value_extract_int64_helper(value);
     if (value->flags & CborIteratorFlag_NegativeInteger)
         *result = -*result - 1;
@@ -395,7 +407,9 @@ CBOR_INLINE_API bool cbor_value_is_tag(const CborValue *value)
 { return value->type == CborTagType; }
 CBOR_INLINE_API CborError cbor_value_get_tag(const CborValue *value, CborTag *result)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_tag(value));
+#endif
     *result = _cbor_value_extract_int64_helper(value);
     return CborNoError;
 }
@@ -410,7 +424,9 @@ CBOR_INLINE_API bool cbor_value_is_text_string(const CborValue *value)
 CBOR_INLINE_API CborError cbor_value_get_string_length(const CborValue *value, size_t *length)
 {
     uint64_t v;
+#ifdef HOST_BUILD
     assert(cbor_value_is_byte_string(value) || cbor_value_is_text_string(value));
+#endif
     if (!cbor_value_is_length_known(value))
         return CborErrorUnknownLength;
     v = _cbor_value_extract_int64_helper(value);
@@ -430,26 +446,34 @@ CBOR_API CborError cbor_value_calculate_string_length(const CborValue *value, si
 CBOR_INLINE_API CborError cbor_value_copy_text_string(const CborValue *value, char *buffer,
                                                       size_t *buflen, CborValue *next)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_text_string(value));
+#endif
     return _cbor_value_copy_string(value, buffer, buflen, next);
 }
 CBOR_INLINE_API CborError cbor_value_copy_byte_string(const CborValue *value, uint8_t *buffer,
                                                       size_t *buflen, CborValue *next)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_byte_string(value));
+#endif
     return _cbor_value_copy_string(value, buffer, buflen, next);
 }
 
 CBOR_INLINE_API CborError cbor_value_dup_text_string(const CborValue *value, char **buffer,
                                                      size_t *buflen, CborValue *next)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_text_string(value));
+#endif
     return _cbor_value_dup_string(value, (void **)buffer, buflen, next);
 }
 CBOR_INLINE_API CborError cbor_value_dup_byte_string(const CborValue *value, uint8_t **buffer,
                                                      size_t *buflen, CborValue *next)
 {
+#ifdef HOST_BUILD
     assert(cbor_value_is_byte_string(value));
+#endif
     return _cbor_value_dup_string(value, (void **)buffer, buflen, next);
 }
 
@@ -464,7 +488,9 @@ CBOR_INLINE_API bool cbor_value_is_map(const CborValue *value)
 CBOR_INLINE_API CborError cbor_value_get_array_length(const CborValue *value, size_t *length)
 {
     uint64_t v;
+#ifdef HOST_BUILD
     assert(cbor_value_is_array(value));
+#endif
     if (!cbor_value_is_length_known(value))
         return CborErrorUnknownLength;
     v = _cbor_value_extract_int64_helper(value);
@@ -477,7 +503,9 @@ CBOR_INLINE_API CborError cbor_value_get_array_length(const CborValue *value, si
 CBOR_INLINE_API CborError cbor_value_get_map_length(const CborValue *value, size_t *length)
 {
     uint64_t v;
+#ifdef HOST_BUILD
     assert(cbor_value_is_map(value));
+#endif
     if (!cbor_value_is_length_known(value))
         return CborErrorUnknownLength;
     v = _cbor_value_extract_int64_helper(value);
@@ -499,8 +527,10 @@ CBOR_INLINE_API bool cbor_value_is_float(const CborValue *value)
 CBOR_INLINE_API CborError cbor_value_get_float(const CborValue *value, float *result)
 {
     uint32_t data;
+#ifdef HOST_BUILD
     assert(cbor_value_is_float(value));
     assert(value->flags & CborIteratorFlag_IntegerValueTooLarge);
+#endif
     data = (uint32_t)_cbor_value_decode_int64_internal(value);
     memcpy(result, &data, sizeof(*result));
     return CborNoError;
@@ -511,8 +541,10 @@ CBOR_INLINE_API bool cbor_value_is_double(const CborValue *value)
 CBOR_INLINE_API CborError cbor_value_get_double(const CborValue *value, double *result)
 {
     uint64_t data;
+#ifdef HOST_BUILD
     assert(cbor_value_is_double(value));
     assert(value->flags & CborIteratorFlag_IntegerValueTooLarge);
+#endif
     data = _cbor_value_decode_int64_internal(value);
     memcpy(result, &data, sizeof(*result));
     return CborNoError;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,10 @@ set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+##########################################################################
+
 set(TEST_TARGET testArduinoCloudThing)
+
 set(TEST_SRCS
   src/Arduino.cpp
   src/main.cpp
@@ -36,6 +39,11 @@ set(TEST_SRCS
 
 ##########################################################################
 
+set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")
+
+##########################################################################
+
 add_executable(
   ${TEST_TARGET}
   ${TEST_SRCS}
@@ -44,9 +52,13 @@ add_executable(
 ##########################################################################
 
 add_custom_command(TARGET ${TEST_TARGET} POST_BUILD
-    COMMAND ${CMAKE_BINARY_DIR}/bin/${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    COMMENT "Exeuting unit tests ..."
+  COMMENT "Exeuting unit tests ..."
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND lcov --directory . --zerocounters
+  COMMAND bin/${TEST_TARGET}
+  COMMAND lcov --directory . --capture --output-file coverage.info
+  COMMAND lcov --remove coverage.info 'test/*' '/usr/*' 'lib/*' --output-file coverage.info
+  COMMAND lcov --list coverage.info
 )
 
 ##########################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,8 @@ set(TEST_SRCS
 
 ##########################################################################
 
+add_definitions(-DHOST_BUILD)
+
 set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")
 

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -412,4 +412,38 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   }
 
   /************************************************************************************/
+
+  WHEN("A payload containing a invalid CBOR key is parsed")
+  {
+    GIVEN("CloudProtocol::V1")
+    {
+      ArduinoCloudThing thing(CloudProtocol::V1);
+      thing.begin();
+
+      int test = 0;
+      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+
+      /* [{"undef": 123, "n": "test", "v": 1}] = 81 A3 65 75 6E 64 65 66 18 7B 61 6E 64 74 65 73 74 61 76 01 */
+      uint8_t const payload[] = {0x81, 0xA3, 0x65, 0x75, 0x6E, 0x64, 0x65, 0x66, 0x18, 0x7B, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0x01};
+      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+
+      REQUIRE(test == 1);
+    }
+    GIVEN("CloudProtocol::V2")
+    {
+      ArduinoCloudThing thing(CloudProtocol::V2);
+      thing.begin();
+
+      int test = 0;
+      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+
+      /* [{123: 123, 0: "test", 2: 1}] = 81 A3 18 7B 18 7B 00 64 74 65 73 74 02 01 */
+      uint8_t const payload[] = {0x81, 0xA3, 0x18, 0x7B, 0x18, 0x7B, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
+      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+
+      REQUIRE(test == 1);
+    }
+  }
+
+  /************************************************************************************/
 }


### PR DESCRIPTION
This PR fixes #7. The initial proposed solution of defining `assert` and `static_assert` as empty macro functions does not really work (**compile**).

@facchinm What's your take on this solution? Do you know where `cbor_assert` is defined?