### PR TITLE
Removing enum class CloudProtocol since the 'decode' function decodes…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
-build
 *~
+
+build
+bin
+CMakeFiles
+
 .project
 .cproject
+
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+

--- a/src/ArduinoCloudProperty.hpp
+++ b/src/ArduinoCloudProperty.hpp
@@ -34,11 +34,6 @@
  * TYPEDEF
  ******************************************************************************/
 
-enum class CloudProtocol {
-  V1, /* [{"n": "test", "vb": true}] */
-  V2  /* [{0: "test", 4: true}]      */
-};
-
 enum class Permission {
   Read, Write, ReadWrite
 };
@@ -97,7 +92,7 @@ public:
   bool shouldBeUpdated        ();
   void execCallbackOnChange   ();
 
-  void append                 (CborEncoder * encoder, CloudProtocol const cloud_protocol);
+  void append                 (CborEncoder * encoder);
 
 private:
 
@@ -117,7 +112,7 @@ private:
   unsigned long      _last_updated_millis,
                      _update_interval_millis;
 
-  void appendValue(CborEncoder * mapEncoder, CloudProtocol const cloud_protocol) const;
+  void appendValue(CborEncoder * mapEncoder) const;
   bool isValueDifferent(T const lhs, T const rhs) const;
 
   T getInitialMinDeltaPropertyValue() const;

--- a/src/ArduinoCloudProperty.ipp
+++ b/src/ArduinoCloudProperty.ipp
@@ -103,16 +103,14 @@ void ArduinoCloudProperty<T>::execCallbackOnChange() {
 }
 
 template <typename T>
-void ArduinoCloudProperty<T>::append(CborEncoder * encoder, CloudProtocol const cloud_protocol) {
+void ArduinoCloudProperty<T>::append(CborEncoder * encoder) {
   if (isReadableByCloud()) {
     CborEncoder mapEncoder;
 
-    cbor_encoder_create_map(encoder, &mapEncoder, CborIndefiniteLength);
-    
-    if     (cloud_protocol == CloudProtocol::V1) cbor_encode_text_stringz(&mapEncoder, "n");
-    else if(cloud_protocol == CloudProtocol::V2) cbor_encode_int         (&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));    
-    cbor_encode_text_stringz(&mapEncoder, _name.c_str());
-    appendValue(&mapEncoder, cloud_protocol);
+    cbor_encoder_create_map     (encoder, &mapEncoder, CborIndefiniteLength);
+    cbor_encode_int             (&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));    
+    cbor_encode_text_stringz    (&mapEncoder, _name.c_str());
+    appendValue                 (&mapEncoder);
     cbor_encoder_close_container(encoder, &mapEncoder);
 
     _shadow_property = _property;
@@ -126,30 +124,26 @@ void ArduinoCloudProperty<T>::append(CborEncoder * encoder, CloudProtocol const 
  ******************************************************************************/
 
 template <>
-inline void ArduinoCloudProperty<bool>::appendValue(CborEncoder * mapEncoder, CloudProtocol const cloud_protocol) const {
-  if     (cloud_protocol == CloudProtocol::V1) cbor_encode_text_stringz(mapEncoder, "vb");
-  else if(cloud_protocol == CloudProtocol::V2) cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::BooleanValue));    
+inline void ArduinoCloudProperty<bool>::appendValue(CborEncoder * mapEncoder) const {
+  cbor_encode_int    (mapEncoder, static_cast<int>(CborIntegerMapKey::BooleanValue));    
   cbor_encode_boolean(mapEncoder, _property);
 }
 
 template <>
-inline void ArduinoCloudProperty<int>::appendValue(CborEncoder * mapEncoder, CloudProtocol const cloud_protocol) const {
-  if     (cloud_protocol == CloudProtocol::V1) cbor_encode_text_stringz(mapEncoder, "v");
-  else if(cloud_protocol == CloudProtocol::V2) cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
+inline void ArduinoCloudProperty<int>::appendValue(CborEncoder * mapEncoder) const {
+  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
   cbor_encode_int(mapEncoder, _property);
 }
 
 template <>
-inline void ArduinoCloudProperty<float>::appendValue(CborEncoder * mapEncoder, CloudProtocol const cloud_protocol) const {
-  if     (cloud_protocol == CloudProtocol::V1) cbor_encode_text_stringz(mapEncoder, "v");
-  else if(cloud_protocol == CloudProtocol::V2) cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
+inline void ArduinoCloudProperty<float>::appendValue(CborEncoder * mapEncoder) const {
+  cbor_encode_int  (mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
   cbor_encode_float(mapEncoder, _property);
 }
 
 template <>
-inline void ArduinoCloudProperty<String>::appendValue(CborEncoder * mapEncoder, CloudProtocol const cloud_protocol) const {
-  if     (cloud_protocol == CloudProtocol::V1) cbor_encode_text_stringz(mapEncoder, "vs");
-  else if(cloud_protocol == CloudProtocol::V2) cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::StringValue));
+inline void ArduinoCloudProperty<String>::appendValue(CborEncoder * mapEncoder) const {
+  cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::StringValue));
   cbor_encode_text_stringz(mapEncoder, _property.c_str());
 }
 

--- a/src/ArduinoCloudPropertyContainer.cpp
+++ b/src/ArduinoCloudPropertyContainer.cpp
@@ -44,9 +44,9 @@ int ArduinoCloudPropertyContainer::getNumOfChangedProperties() {
   return num_changes_properties;
 }
 
-void ArduinoCloudPropertyContainer::appendChangedProperties(CborEncoder * arrayEncoder, CloudProtocol const cloud_protocol) {
-  appendChangedProperties<bool>  (_bool_property_list,   arrayEncoder, cloud_protocol);
-  appendChangedProperties<int>   (_int_property_list,    arrayEncoder, cloud_protocol);
-  appendChangedProperties<float> (_float_property_list,  arrayEncoder, cloud_protocol);
-  appendChangedProperties<String>(_string_property_list, arrayEncoder, cloud_protocol);
+void ArduinoCloudPropertyContainer::appendChangedProperties(CborEncoder * arrayEncoder) {
+  appendChangedProperties<bool>  (_bool_property_list,   arrayEncoder);
+  appendChangedProperties<int>   (_int_property_list,    arrayEncoder);
+  appendChangedProperties<float> (_float_property_list,  arrayEncoder);
+  appendChangedProperties<String>(_string_property_list, arrayEncoder);
 }

--- a/src/ArduinoCloudPropertyContainer.hpp
+++ b/src/ArduinoCloudPropertyContainer.hpp
@@ -36,7 +36,7 @@ public:
 
   bool isPropertyInContainer    (Type const type, String const & name);
   int  getNumOfChangedProperties();
-  void appendChangedProperties  (CborEncoder * arrayEncoder, CloudProtocol const cloud_protocol);
+  void appendChangedProperties  (CborEncoder * arrayEncoder);
 
   inline ArduinoCloudProperty<bool>   * getPropertyBool  (String const & name) { return getProperty(_bool_property_list,   name); }
   inline ArduinoCloudProperty<int>    * getPropertyInt   (String const & name) { return getProperty(_int_property_list,    name); }
@@ -65,7 +65,7 @@ private:
   int getNumOfChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list);
 
   template <typename T>
-  void appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder, CloudProtocol const cloud_protocol);
+  void appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder);
 
 };
 

--- a/src/ArduinoCloudPropertyContainer.ipp
+++ b/src/ArduinoCloudPropertyContainer.ipp
@@ -52,11 +52,11 @@ int ArduinoCloudPropertyContainer::getNumOfChangedProperties(LinkedList<ArduinoC
 }
 
 template <typename T>
-void ArduinoCloudPropertyContainer::appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder, CloudProtocol const cloud_protocol) {
+void ArduinoCloudPropertyContainer::appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder) {
   for (int i = 0; i < list.size(); i++) {
     ArduinoCloudProperty<T> * p = list.get(i);
     if (p->shouldBeUpdated() && p->isReadableByCloud()) {
-      p->append(arrayEncoder, cloud_protocol);
+      p->append(arrayEncoder);
     }
   }
 }

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -47,7 +47,7 @@ static long const DAYS      = 86400;
 class ArduinoCloudThing {
 
 public:
-  ArduinoCloudThing(CloudProtocol const cloud_protocol = CloudProtocol::V2);
+  ArduinoCloudThing();
 
   void begin();
 
@@ -64,7 +64,6 @@ public:
 
 private:
 
-  CloudProtocol           const _cloud_protocol;
   bool                          _status = OFF;
   char                          _uuid[33];
   ArduinoCloudPropertyContainer _property_cont;
@@ -96,7 +95,7 @@ private:
     inline T const get  () const { return _entry; }
 
     inline bool    isSet() const { return _is_set; }
-    inline bool    reset()       { _is_set = false; }
+    inline void    reset()       { _is_set = false; }
 
   private:
 

--- a/test/src/test_callback.cpp
+++ b/test/src/test_callback.cpp
@@ -33,7 +33,7 @@ SCENARIO("A callback is registered via 'onUpdate' to be called on property chang
 
   GIVEN("CloudProtocol::V1")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
 
     int test = 10;
@@ -48,7 +48,7 @@ SCENARIO("A callback is registered via 'onUpdate' to be called on property chang
   }
   GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V2);
+    ArduinoCloudThing thing;
     thing.begin();
 
     int test = 10;
@@ -78,16 +78,16 @@ void switch_callback()
 
 SCENARIO("A (boolean) property is manipulated in the callback to its origin state", "[ArduinoCloudThing::decode]")
 {
-  GIVEN("CloudProtocol::V1")
+  GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
     encode(thing);
 
     thing.addPropertyReal(switch_turned_on, "switch_turned_on", Permission::ReadWrite).onUpdate(switch_callback);
 
-    /* [{"n": "switch_turned_on", "vb": true}] = 81 A2 61 6E 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 62 76 62 F5 */
-    uint8_t const payload[] = {0x81, 0xA2, 0x61, 0x6E, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x62, 0x76, 0x62, 0xF5};
+    /* [{0: "switch_turned_on", 4: true}] = 81 A2 00 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 04 F5 */
+    uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x04, 0xF5};
     int const payload_length = sizeof(payload)/sizeof(uint8_t);
     thing.decode(payload, payload_length);
 
@@ -98,8 +98,8 @@ SCENARIO("A (boolean) property is manipulated in the callback to its origin stat
      * the cloud.
      */
 
-    /* [{"n": "switch_turned_on", "vb": false}] = 81 BF 61 6E 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 62 76 62 F4 FF */
-    std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x62, 0x76, 0x62, 0xF4, 0xFF};
+    /* [{0: "switch_turned_on", 4: false}] = 81 BF 00 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 04 F4 FF */
+    std::vector<uint8_t> const expected = {0x81, 0xBF, 0x00, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x04, 0xF4, 0xFF};
     std::vector<uint8_t> const actual = encode(thing);
     REQUIRE(actual == expected);
   }

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -10,7 +10,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       bool test = true;
@@ -25,7 +25,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       bool test = true;
@@ -46,7 +46,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -61,7 +61,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -82,7 +82,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       float test = 0.0f;
@@ -97,7 +97,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       float test = 0.0f;
@@ -118,7 +118,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       String str = "test";
@@ -132,7 +132,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       String str = "test";
@@ -154,7 +154,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     {
       WHEN("Multiple properties of different type are changed via CBOR message")
       {
-        ArduinoCloudThing thing(CloudProtocol::V1);
+        ArduinoCloudThing thing;
         thing.begin();
 
         bool   bool_test = false;
@@ -183,7 +183,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       WHEN("Multiple String properties are changed via CBOR message")
       {
-        ArduinoCloudThing thing(CloudProtocol::V1);
+        ArduinoCloudThing thing;
         thing.begin();
 
         String str_1("hello"),
@@ -215,7 +215,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     {
       WHEN("Multiple properties of different type are changed via CBOR message")
       {
-        ArduinoCloudThing thing(CloudProtocol::V2);
+        ArduinoCloudThing thing;
         thing.begin();
 
         bool   bool_test = false;
@@ -244,7 +244,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       WHEN("Multiple String properties are changed via CBOR message")
       {
-        ArduinoCloudThing thing(CloudProtocol::V2);
+        ArduinoCloudThing thing;
         thing.begin();
 
         String str_1("hello"),
@@ -277,7 +277,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       String str = "hello";
@@ -291,7 +291,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       String str = "hello";
@@ -311,7 +311,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -325,7 +325,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -345,7 +345,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -359,7 +359,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -379,7 +379,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -395,7 +395,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -417,7 +417,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
   {
     GIVEN("CloudProtocol::V1")
     {
-      ArduinoCloudThing thing(CloudProtocol::V1);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;
@@ -431,7 +431,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
     }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int test = 0;

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -8,19 +8,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("Only the boolean 'status' default property has been added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-
-      /* [{"n": "status", "vb": true}] = 81 BF 61 6E 66 73 74 61 74 75 73 62 76 62 F5 FF */
-      std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x66, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x62, 0x76, 0x62, 0xF5, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       /* [{0: "status", 4: true}] = 81 BF 00 66 73 74 61 74 75 73 04 F5 FF */
@@ -34,23 +24,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("A 'bool' property is added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-      encode(thing);
-
-      bool test = true;
-      thing.addPropertyReal(test, "test", Permission::ReadWrite);
-
-      /* [{"n": "test", "vb": true}] = 81 BF 61 6E 64 74 65 73 74 62 76 62 F5 FF */
-      std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x62, 0x76, 0x62, 0xF5, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
@@ -68,23 +44,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("A 'int' property is added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-      encode(thing);
-
-      int int_test = 123;
-      thing.addPropertyReal(int_test, "test", Permission::ReadWrite);
-
-      /* [{"n": "test", "v": 123}] = 81 BF 61 6E 64 74 65 73 74 61 76 18 7B FF */
-      std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0x18, 0x7B, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
@@ -102,23 +64,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("A 'float' property is added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-      encode(thing);
-
-      float float_test = 3.14159;
-      thing.addPropertyReal(float_test, "test", Permission::ReadWrite);
-
-      /* [{"n": "test", "v": 3.141590118408203}] = 81 BF 61 6E 64 74 65 73 74 61 76 FA 40 49 0F D0 FF */
-      std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0xFA, 0x40, 0x49, 0x0F, 0xD0, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
@@ -136,23 +84,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("A 'String' property is added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-      encode(thing);
-
-      String string_test("test");
-      thing.addPropertyReal(string_test, "test", Permission::ReadWrite);
-
-      /* [{"n": "test", "vs": "test"}] = 81 BF 61 6E 64 74 65 73 74 62 76 73 64 74 65 73 74 FF */
-      std::vector<uint8_t> const expected = {0x81, 0xBF, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x62, 0x76, 0x73, 0x64, 0x74, 0x65, 0x73, 0x74, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
@@ -170,31 +104,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   WHEN("Multiple properties are added")
   {
-    GIVEN("CloudProtocol::V1")
-    {
-      ArduinoCloudThing thing(CloudProtocol::V1);
-      thing.begin();
-
-      int    int_test = 1;
-      bool   bool_test = false;
-      float  float_test = 2.0f;
-      String str_test("str_test");
-
-      thing.addPropertyReal(int_test,   "int_test",   Permission::ReadWrite);
-      thing.addPropertyReal(bool_test,  "bool_test",  Permission::ReadWrite);
-      thing.addPropertyReal(float_test, "float_test", Permission::ReadWrite);
-      thing.addPropertyReal(str_test,   "str_test",   Permission::ReadWrite);
-
-      /* [{"n": "status", "vb": true}, {"n": "bool_test", "vb": false}, {"n": "int_test", "v": 1}, {"n": "float_test", "v": 2.0}, {"n": "str_test", "vs": "str_test"}]
-       * = 85 BF 61 6E 66 73 74 61 74 75 73 62 76 62 F5 FF BF 61 6E 69 62 6F 6F 6C 5F 74 65 73 74 62 76 62 F4 FF BF 61 6E 68 69 6E 74 5F 74 65 73 74 61 76 01 FF BF 61 6E 6A 66 6C 6F 61 74 5F 74 65 73 74 61 76 FA 40 00 00 00 FF BF 61 6E 68 73 74 72 5F 74 65 73 74 62 76 73 68 73 74 72 5F 74 65 73 74 FF
-       */
-      std::vector<uint8_t> const expected = {0x85, 0xBF, 0x61, 0x6E, 0x66, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x62, 0x76, 0x62, 0xF5, 0xFF, 0xBF, 0x61, 0x6E, 0x69, 0x62, 0x6F, 0x6F, 0x6C, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x62, 0x76, 0x62, 0xF4, 0xFF, 0xBF, 0x61, 0x6E, 0x68, 0x69, 0x6E, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0x01, 0xFF, 0xBF, 0x61, 0x6E, 0x6A, 0x66, 0x6C, 0x6F, 0x61, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xFF, 0xBF, 0x61, 0x6E, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x62, 0x76, 0x73, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0xFF};
-      std::vector<uint8_t> const actual = encode(thing);
-      REQUIRE(actual == expected);
-    }
     GIVEN("CloudProtocol::V2")
     {
-      ArduinoCloudThing thing(CloudProtocol::V2);
+      ArduinoCloudThing thing;
       thing.begin();
 
       int    int_test = 1;

--- a/test/src/test_publishEvery.cpp
+++ b/test/src/test_publishEvery.cpp
@@ -6,9 +6,9 @@ SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThi
 {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V1")
+  GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
     REQUIRE(encode(thing).size() != 0); /* Encoding the 'status' property */
 
@@ -57,10 +57,6 @@ SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThi
         }
       }
     }
-  }
-  GIVEN("CloudProtocol::V2")
-  {
-    /* Business logic is the same regardless of protocol version - no separate test needed */
   }
 
   /************************************************************************************/

--- a/test/src/test_publishOnChange.cpp
+++ b/test/src/test_publishOnChange.cpp
@@ -6,9 +6,9 @@ SCENARIO("A Arduino cloud property is published on value change", "[ArduinoCloud
 {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V1")
+  GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
     REQUIRE(encode(thing).size() != 0); /* Encoding the 'status' property */
 
@@ -40,10 +40,6 @@ SCENARIO("A Arduino cloud property is published on value change", "[ArduinoCloud
         }
       }
     }
-  }
-  GIVEN("CloudProtocol::V2")
-  {
-    /* Business logic is the same regardless of protocol version - no separate test needed */
   }
 
   /************************************************************************************/

--- a/test/src/test_publishOnChangeRateLimit.cpp
+++ b/test/src/test_publishOnChangeRateLimit.cpp
@@ -6,9 +6,9 @@ SCENARIO("A Arduino cloud property is published on value change but the update r
 {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V1")
+  GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
     REQUIRE(encode(thing).size() != 0); /* Encoding the 'status' property */
 
@@ -62,10 +62,6 @@ SCENARIO("A Arduino cloud property is published on value change but the update r
         }
       }
     }
-  }
-  GIVEN("CloudProtocol::V2")
-  {
-    /* Business logic is the same regardless of protocol version - no separate test needed */
   }
 
   /************************************************************************************/

--- a/test/src/test_readOnly.cpp
+++ b/test/src/test_readOnly.cpp
@@ -6,25 +6,20 @@ SCENARIO("A Arduino cloud property is marked 'read only'", "[ArduinoCloudThing::
 {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V1")
+  GIVEN("CloudProtocol::V2")
   {
-    ArduinoCloudThing thing(CloudProtocol::V1);
+    ArduinoCloudThing thing;
     thing.begin();
 
     int test = 0;
     thing.addPropertyReal(test, "test", Permission::Read);
 
-    /* [{"n": "test", "v": 7}] = 81 A2 61 6E 64 74 65 73 74 61 76 07 */
-
-    uint8_t const payload[] = {0x81, 0xA2, 0x61, 0x6E, 0x64, 0x74, 0x65, 0x73, 0x74, 0x61, 0x76, 0x07};
+    /* [{0: "test", 2: 7}] = 81 A2 00 64 74 65 73 74 02 07 */
+    uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x07};
     int const payload_length = sizeof(payload)/sizeof(uint8_t);
     thing.decode(payload, payload_length);
 
     REQUIRE(test == 0);
-  }
-  GIVEN("CloudProtocol::V2")
-  {
-    /* TODO */
   }
 
   /************************************************************************************/

--- a/test/src/test_writeOnly.cpp
+++ b/test/src/test_writeOnly.cpp
@@ -6,7 +6,7 @@ SCENARIO("A Arduino cloud property is marked 'write only'", "[ArduinoCloudThing:
 {
   /************************************************************************************/
 
-  ArduinoCloudThing thing(CloudProtocol::V1);
+  ArduinoCloudThing thing;
   thing.begin();
   REQUIRE(encode(thing).size() != 0); /* Encoding the 'status' property */
 


### PR DESCRIPTION
… both V1/V2 and encoding will only happen in V2 anymore. Decoding for V2 shall be removed at a later point in time