### PR TITLE
Add code formatting check to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,11 @@ matrix:
       script:
         # check code formatting
         - find . -regextype posix-extended -path './.git' -prune -or -path './src/lib' -prune -or -path './test/external' -prune -or \( -iregex '.*\.((ino)|(h)|(hpp)|(hh)|(hxx)|(h\+\+)|(cpp)|(cc)|(cxx)|(c\+\+)|(cp)|(c)|(ipp)|(ii)|(ixx)|(inl)|(tpp)|(txx)|(tpl))$' -and -type f \) -print0 | xargs -0 -L1 bash -c 'if ! diff $0 <(astyle --options=${HOME}/astyle/examples_formatter.conf --dry-run < $0); then echo "Non-compliant code formatting in $0"; false; fi'
+
+notifications:
+  webhooks:
+    urls:
+      # TravisBuddy will automatically comment on any PR that results in a failed Travis CI build, which will cause the PR author to get a notification
+      - https://www.travisbuddy.com/
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,47 @@
 language: cpp
 sudo: enabled
 
-install:
-  - sudo apt-get install lcov
+matrix:
+  include:
+    - env:
+        - NAME=Test
 
-before_script:
-  - cd test && mkdir build && cd build
+      install:
+        - sudo apt-get install lcov
 
-script:
-  - cmake ..
-  - make
+      before_script:
+        - cd test && mkdir build && cd build
 
-after_success:
-  - lcov --directory . --zerocounters
-  - bin/testArduinoCloudThing
-  - lcov --directory . --capture --output-file coverage.info
-  - lcov --remove coverage.info 'test/*' '/usr/*' 'lib/*' --output-file coverage.info
-  - lcov --list coverage.info
-  - bash <(curl -s https://codecov.io/bash) -f coverage.info
-  - cd ..
-  - rm -rf build
+      script:
+        - cmake ..
+        - make
 
+      after_success:
+        - lcov --directory . --zerocounters
+        - bin/testArduinoCloudThing
+        - lcov --directory . --capture --output-file coverage.info
+        - lcov --remove coverage.info 'test/*' '/usr/*' 'lib/*' --output-file coverage.info
+        - lcov --list coverage.info
+        - bash <(curl -s https://codecov.io/bash) -f coverage.info
+        - cd ..
+        - rm -rf build
+
+    - env:
+        - NAME=Code Formatting Check
+
+      install:
+        # install Artistic Style code formatter tool: http://astyle.sourceforge.net
+        - |
+          mkdir "${HOME}/astyle";
+          wget --no-verbose --output-document="${HOME}/astyle/astyle.tar.gz" "https://iweb.dl.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz";
+          tar --extract --file="${HOME}/astyle/astyle.tar.gz" --directory="${HOME}/astyle";
+          cd "${HOME}/astyle/astyle/build/gcc";
+          make;
+          export PATH=$PWD/bin:$PATH;
+          cd "$TRAVIS_BUILD_DIR"
+        # download Arduino's Artistic Style configuration file
+        - wget --directory-prefix="${HOME}/astyle" https://raw.githubusercontent.com/arduino/Arduino/master/build/shared/examples_formatter.conf
+
+      script:
+        # check code formatting
+        - find . -regextype posix-extended -path './.git' -prune -or -path './src/lib' -prune -or -path './test/external' -prune -or \( -iregex '.*\.((ino)|(h)|(hpp)|(hh)|(hxx)|(h\+\+)|(cpp)|(cc)|(cxx)|(c\+\+)|(cp)|(c)|(ipp)|(ii)|(ixx)|(inl)|(tpp)|(txx)|(tpl))$' -and -type f \) -print0 | xargs -0 -L1 bash -c 'if ! diff $0 <(astyle --options=${HOME}/astyle/examples_formatter.conf --dry-run < $0); then echo "Non-compliant code formatting in $0"; false; fi'

--- a/src/ArduinoCloudProperty.hpp
+++ b/src/ArduinoCloudProperty.hpp
@@ -19,7 +19,7 @@
 #define ARDUINO_CLOUD_PROPERTY_HPP_
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include <Arduino.h>
@@ -27,11 +27,11 @@
 #include "lib/tinycbor/cbor-lib.h"
 
 /******************************************************************************
- * TYPEDEF
+   TYPEDEF
  ******************************************************************************/
 
 /******************************************************************************
- * TYPEDEF
+   TYPEDEF
  ******************************************************************************/
 
 enum class Permission {
@@ -47,110 +47,117 @@ enum class UpdatePolicy {
 };
 
 /* Source: https://tools.ietf.org/html/rfc8428#section-6 */
-enum class CborIntegerMapKey : int
-{
-   BaseVersion  = -1, /* bver */
-   BaseName     = -2, /* bn   */
-   BaseTime     = -3, /* bt   */
-   BaseUnit     = -4, /* bu   */
-   BaseValue    = -5, /* bv   */
-   BaseSum      = -6, /* bs   */
-   Name         =  0, /* n    */
-   Unit         =  1, /* u    */
-   Value        =  2, /* v    */
-   StringValue  =  3, /* vs   */
-   BooleanValue =  4, /* vb   */
-   Sum          =  5, /* s    */
-   Time         =  6, /* t    */
-   UpdateTime   =  7, /* ut   */
-   DataValue    =  8  /* vd   */
+enum class CborIntegerMapKey : int {
+  BaseVersion  = -1, /* bver */
+  BaseName     = -2, /* bn   */
+  BaseTime     = -3, /* bt   */
+  BaseUnit     = -4, /* bu   */
+  BaseValue    = -5, /* bv   */
+  BaseSum      = -6, /* bs   */
+  Name         =  0, /* n    */
+  Unit         =  1, /* u    */
+  Value        =  2, /* v    */
+  StringValue  =  3, /* vs   */
+  BooleanValue =  4, /* vb   */
+  Sum          =  5, /* s    */
+  Time         =  6, /* t    */
+  UpdateTime   =  7, /* ut   */
+  DataValue    =  8  /* vd   */
 };
 
 typedef void(*UpdateCallbackFunc)(void);
 
 /******************************************************************************
- * CLASS DECLARATION
+   CLASS DECLARATION
  ******************************************************************************/
 
 template <typename T>
 class ArduinoCloudProperty {
-public:
+  public:
 
-  ArduinoCloudProperty(T & property, String const & name, Permission const permission);
+    ArduinoCloudProperty(T & property, String const & name, Permission const permission);
 
-  void writeByCloud(T const val);
+    void writeByCloud(T const val);
 
-  /* Composable configuration of the ArduinoCloudProperty class */
-  ArduinoCloudProperty<T> & onUpdate       (UpdateCallbackFunc func);
-  ArduinoCloudProperty<T> & onSync         (void (*func)(ArduinoCloudProperty<T> property));
-  ArduinoCloudProperty<T> & publishOnChange(T const min_delta_property, unsigned long const min_time_between_updates_millis = 0);
-  ArduinoCloudProperty<T> & publishEvery   (unsigned long const seconds);
+    /* Composable configuration of the ArduinoCloudProperty class */
+    ArduinoCloudProperty<T> & onUpdate(UpdateCallbackFunc func);
+    ArduinoCloudProperty<T> & onSync(void (*func)(ArduinoCloudProperty<T> property));
+    ArduinoCloudProperty<T> & publishOnChange(T const min_delta_property, unsigned long const min_time_between_updates_millis = 0);
+    ArduinoCloudProperty<T> & publishEvery(unsigned long const seconds);
 
-  inline String name              () const { return _name; }
-  inline bool   isReadableByCloud () const { return (_permission == Permission::Read ) || (_permission == Permission::ReadWrite); }
-  inline bool   isWriteableByCloud() const { return (_permission == Permission::Write) || (_permission == Permission::ReadWrite); }
+    inline String name() const {
+      return _name;
+    }
+    inline bool   isReadableByCloud() const {
+      return (_permission == Permission::Read) || (_permission == Permission::ReadWrite);
+    }
+    inline bool   isWriteableByCloud() const {
+      return (_permission == Permission::Write) || (_permission == Permission::ReadWrite);
+    }
 
-  bool shouldBeUpdated        ();
-  void execCallbackOnChange   ();
-  void execCallbackOnSync     ();
-  void forceCallbackOnChange  ();
-  void setPreviousCloudChangeTimestamp  (unsigned long cloudChangeTime);
-  void setLastCloudChangeTimestamp      (unsigned long cloudChangeTime);
-  void setLastLocalChangeTimestamp      (unsigned long localChangeTime);
-  unsigned long getPreviousCloudChangeTimestamp();
-  unsigned long getLastCloudChangeTimestamp();
-  unsigned long getLastLocalChangeTimestamp();
-  void setPropertyValue       (T const val);
-  void setCloudShadowValue    (T const val);
-  T    getCloudShadowValue    ();
-  void setLocalShadowValue    (T const val);
-  T    getLocalShadowValue    ();         
-  void updateTime             (unsigned long changeEventTime);
-  bool isChangedLocally       ();
-  void append                 (CborEncoder * encoder);
+    bool shouldBeUpdated();
+    void execCallbackOnChange();
+    void execCallbackOnSync();
+    void forceCallbackOnChange();
+    void setPreviousCloudChangeTimestamp(unsigned long cloudChangeTime);
+    void setLastCloudChangeTimestamp(unsigned long cloudChangeTime);
+    void setLastLocalChangeTimestamp(unsigned long localChangeTime);
+    unsigned long getPreviousCloudChangeTimestamp();
+    unsigned long getLastCloudChangeTimestamp();
+    unsigned long getLastLocalChangeTimestamp();
+    void setPropertyValue(T const val);
+    void setCloudShadowValue(T const val);
+    T    getCloudShadowValue();
+    void setLocalShadowValue(T const val);
+    T    getLocalShadowValue();
+    void updateTime(unsigned long changeEventTime);
+    bool isChangedLocally();
+    void append(CborEncoder * encoder);
 
-private:
+  private:
 
-  T                & _property,
-                     _cloud_shadow_property,
-                     _local_shadow_property;
-  String             _name;
-  Permission         _permission;
-  UpdateCallbackFunc _update_callback_func;
-  void               (*_sync_callback_func)(ArduinoCloudProperty<T> property);
+    T                & _property,
+    _cloud_shadow_property,
+    _local_shadow_property;
+    String             _name;
+    Permission         _permission;
+    UpdateCallbackFunc _update_callback_func;
+    void (*_sync_callback_func)(ArduinoCloudProperty<T> property);
 
-  UpdatePolicy       _update_policy;
-  bool               _has_been_updated_once,
-                     _has_been_modified_in_callback;
-  /* Variables used for UpdatePolicy::OnChange */
-  T                  _min_delta_property;
-  unsigned long      _min_time_between_updates_millis;
-  /* Variables used for UpdatePolicy::TimeInterval */
-  unsigned long      _last_updated_millis,
-                     _update_interval_millis;
-  /* Variables used for reconnection sync*/
-  unsigned long      _last_change_timestamp;
-  unsigned long      _last_local_change_timestamp;
-  unsigned long      _last_cloud_change_timestamp;
-  unsigned long      _previous_cloud_change_timestamp;
-        
+    UpdatePolicy       _update_policy;
+    bool               _has_been_updated_once,
+                       _has_been_modified_in_callback;
+    /* Variables used for UpdatePolicy::OnChange */
+    T                  _min_delta_property;
+    unsigned long      _min_time_between_updates_millis;
+    /* Variables used for UpdatePolicy::TimeInterval */
+    unsigned long      _last_updated_millis,
+             _update_interval_millis;
+    /* Variables used for reconnection sync*/
+    unsigned long      _last_change_timestamp;
+    unsigned long      _last_local_change_timestamp;
+    unsigned long      _last_cloud_change_timestamp;
+    unsigned long      _previous_cloud_change_timestamp;
 
-  void appendValue(CborEncoder * mapEncoder) const;
-  bool isValueDifferent(T const lhs, T const rhs) const;
 
-  T getInitialMinDeltaPropertyValue() const;
+    void appendValue(CborEncoder * mapEncoder) const;
+    bool isValueDifferent(T const lhs, T const rhs) const;
+
+    T getInitialMinDeltaPropertyValue() const;
 
 };
 
 /******************************************************************************
- * PROTOTYPE FREE FUNCTIONs
+   PROTOTYPE FREE FUNCTIONs
  ******************************************************************************/
 
 template <typename T>
-inline bool operator == (ArduinoCloudProperty<T> const & lhs, ArduinoCloudProperty<T> const & rhs) { return (lhs.name() == rhs.name()); }
+inline bool operator == (ArduinoCloudProperty<T> const & lhs, ArduinoCloudProperty<T> const & rhs) {
+  return (lhs.name() == rhs.name());
+}
 
 /******************************************************************************
- * TEMPLATE IMPLEMENTATION
+   TEMPLATE IMPLEMENTATION
  ******************************************************************************/
 
 #include "ArduinoCloudProperty.ipp"

--- a/src/ArduinoCloudProperty.ipp
+++ b/src/ArduinoCloudProperty.ipp
@@ -16,38 +16,37 @@
 //
 
 /******************************************************************************
- * CTOR/DTOR
+   CTOR/DTOR
  ******************************************************************************/
 
 template <typename T>
 ArduinoCloudProperty<T>::ArduinoCloudProperty(T & property, String const & name, Permission const permission)
-: _property(property),
-  _cloud_shadow_property(property),
-  _local_shadow_property(property),
-  _name(name),
-  _permission(permission),
-  _update_callback_func(NULL),
-  _sync_callback_func(NULL),
-  _update_policy(UpdatePolicy::OnChange),
-  _has_been_updated_once(false),
-  _has_been_modified_in_callback(false),
-  _min_delta_property(getInitialMinDeltaPropertyValue()),
-  _min_time_between_updates_millis(0),
-  _last_updated_millis(0),
-  _update_interval_millis(0),
-  _last_local_change_timestamp(0),
-  _last_cloud_change_timestamp(0),
-  _previous_cloud_change_timestamp(0)
-{
+  : _property(property),
+    _cloud_shadow_property(property),
+    _local_shadow_property(property),
+    _name(name),
+    _permission(permission),
+    _update_callback_func(NULL),
+    _sync_callback_func(NULL),
+    _update_policy(UpdatePolicy::OnChange),
+    _has_been_updated_once(false),
+    _has_been_modified_in_callback(false),
+    _min_delta_property(getInitialMinDeltaPropertyValue()),
+    _min_time_between_updates_millis(0),
+    _last_updated_millis(0),
+    _update_interval_millis(0),
+    _last_local_change_timestamp(0),
+    _last_cloud_change_timestamp(0),
+    _previous_cloud_change_timestamp(0) {
 }
 
 /******************************************************************************
- * PUBLIC MEMBER FUNCTIONS
+   PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
 template <typename T>
 void ArduinoCloudProperty<T>::writeByCloud(T const val) {
-  if(isWriteableByCloud()) {
+  if (isWriteableByCloud()) {
     _property = val;
     /* _cloud_shadow_property and local_shadow_property are not updated so there will be an update the next time around */
   }
@@ -82,38 +81,38 @@ ArduinoCloudProperty<T> & ArduinoCloudProperty<T>::publishEvery(unsigned long co
 
 template <typename T>
 bool ArduinoCloudProperty<T>::shouldBeUpdated() {
-  if(!_has_been_updated_once) return true;
+  if (!_has_been_updated_once) {
+    return true;
+  }
 
-  if(_has_been_modified_in_callback) {
+  if (_has_been_modified_in_callback) {
     _has_been_modified_in_callback = false;
     return true;
   }
 
-  if     (_update_policy == UpdatePolicy::OnChange) {
+  if (_update_policy == UpdatePolicy::OnChange) {
     return (isValueDifferent(_property, _cloud_shadow_property) && ((millis() - _last_updated_millis) >= (_min_time_between_updates_millis)));
-  }
-  else if(_update_policy == UpdatePolicy::TimeInterval) {
+  } else if (_update_policy == UpdatePolicy::TimeInterval) {
     return ((millis() - _last_updated_millis) >= _update_interval_millis);
-  }
-  else {
+  } else {
     return false;
   }
 }
 
 template <typename T>
 void ArduinoCloudProperty<T>::forceCallbackOnChange() {
-  if(_update_callback_func != NULL) {
+  if (_update_callback_func != NULL) {
     _update_callback_func();
   }
 }
 
 template <typename T>
 void ArduinoCloudProperty<T>::execCallbackOnChange() {
-  if(isValueDifferent(_property, _cloud_shadow_property)) {
-    if(_update_callback_func != NULL) {
+  if (isValueDifferent(_property, _cloud_shadow_property)) {
+    if (_update_callback_func != NULL) {
       _update_callback_func();
     }
-    if(!isValueDifferent(_property, _cloud_shadow_property)) {
+    if (!isValueDifferent(_property, _cloud_shadow_property)) {
       _has_been_modified_in_callback = true;
     }
   }
@@ -121,7 +120,7 @@ void ArduinoCloudProperty<T>::execCallbackOnChange() {
 
 template <typename T>
 void ArduinoCloudProperty<T>::execCallbackOnSync() {
-  if(_sync_callback_func != NULL) {
+  if (_sync_callback_func != NULL) {
     _sync_callback_func(*this);
   }
 }
@@ -131,14 +130,14 @@ void ArduinoCloudProperty<T>::append(CborEncoder * encoder) {
   if (isReadableByCloud()) {
     CborEncoder mapEncoder;
 
-    cbor_encoder_create_map     (encoder, &mapEncoder, CborIndefiniteLength);
-    cbor_encode_int             (&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));    
-    cbor_encode_text_stringz    (&mapEncoder, _name.c_str());
-    appendValue                 (&mapEncoder);
+    cbor_encoder_create_map(encoder, &mapEncoder, CborIndefiniteLength);
+    cbor_encode_int(&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));
+    cbor_encode_text_stringz(&mapEncoder, _name.c_str());
+    appendValue(&mapEncoder);
     cbor_encoder_close_container(encoder, &mapEncoder);
 
     _cloud_shadow_property = _property;
- 
+
     _has_been_updated_once = true;
     _last_updated_millis = millis();
   }
@@ -159,21 +158,21 @@ void ArduinoCloudProperty<T>::updateTime(unsigned long changeEventTime) {
 
 template <typename T>
 void ArduinoCloudProperty<T>::setPropertyValue(T const val) {
-  if(isWriteableByCloud()) {
+  if (isWriteableByCloud()) {
     _property = val;
   }
 }
 
 template <typename T>
 void ArduinoCloudProperty<T>::setCloudShadowValue(T const val) {
-  if(isWriteableByCloud()) {
+  if (isWriteableByCloud()) {
     _cloud_shadow_property = val;
   }
 }
 
 template <typename T>
 void ArduinoCloudProperty<T>::setLocalShadowValue(T const val) {
-  if(isWriteableByCloud()) {
+  if (isWriteableByCloud()) {
     _local_shadow_property = val;
   }
 }
@@ -221,30 +220,30 @@ unsigned long ArduinoCloudProperty<T>::getLastLocalChangeTimestamp() {
 
 
 /******************************************************************************
- * PRIVATE MEMBER FUNCTIONS 
+   PRIVATE MEMBER FUNCTIONS
  ******************************************************************************/
 
 template <>
 inline void ArduinoCloudProperty<bool>::appendValue(CborEncoder * mapEncoder) const {
-  cbor_encode_int    (mapEncoder, static_cast<int>(CborIntegerMapKey::BooleanValue));    
+  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::BooleanValue));
   cbor_encode_boolean(mapEncoder, _property);
 }
 
 template <>
 inline void ArduinoCloudProperty<int>::appendValue(CborEncoder * mapEncoder) const {
-  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
+  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::Value));
   cbor_encode_int(mapEncoder, _property);
 }
 
 template <>
 inline void ArduinoCloudProperty<float>::appendValue(CborEncoder * mapEncoder) const {
-  cbor_encode_int  (mapEncoder, static_cast<int>(CborIntegerMapKey::Value));    
+  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::Value));
   cbor_encode_float(mapEncoder, _property);
 }
 
 template <>
 inline void ArduinoCloudProperty<String>::appendValue(CborEncoder * mapEncoder) const {
-  cbor_encode_int         (mapEncoder, static_cast<int>(CborIntegerMapKey::StringValue));
+  cbor_encode_int(mapEncoder, static_cast<int>(CborIntegerMapKey::StringValue));
   cbor_encode_text_stringz(mapEncoder, _property.c_str());
 }
 

--- a/src/ArduinoCloudPropertyContainer.cpp
+++ b/src/ArduinoCloudPropertyContainer.cpp
@@ -16,37 +16,43 @@
 //
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include "ArduinoCloudPropertyContainer.hpp"
 
 /******************************************************************************
- * PUBLIC MEMBER FUNCTIONS
+   PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
 bool ArduinoCloudPropertyContainer::isPropertyInContainer(Type const type, String const & name) {
-  if      (type == Type::Bool  ) return isPropertyInList(_bool_property_list,   name);
-  else if (type == Type::Int   ) return isPropertyInList(_int_property_list,    name);
-  else if (type == Type::Float ) return isPropertyInList(_float_property_list,  name);
-  else if (type == Type::String) return isPropertyInList(_string_property_list, name);
-  else                           return false;
+  if (type == Type::Bool) {
+    return isPropertyInList(_bool_property_list,   name);
+  } else if (type == Type::Int) {
+    return isPropertyInList(_int_property_list,    name);
+  } else if (type == Type::Float) {
+    return isPropertyInList(_float_property_list,  name);
+  } else if (type == Type::String) {
+    return isPropertyInList(_string_property_list, name);
+  } else {
+    return false;
+  }
 }
 
 int ArduinoCloudPropertyContainer::getNumOfChangedProperties() {
   int num_changes_properties = 0;
 
-  num_changes_properties += getNumOfChangedProperties(_bool_property_list  );
-  num_changes_properties += getNumOfChangedProperties(_int_property_list   );
-  num_changes_properties += getNumOfChangedProperties(_float_property_list );
+  num_changes_properties += getNumOfChangedProperties(_bool_property_list);
+  num_changes_properties += getNumOfChangedProperties(_int_property_list);
+  num_changes_properties += getNumOfChangedProperties(_float_property_list);
   num_changes_properties += getNumOfChangedProperties(_string_property_list);
 
   return num_changes_properties;
 }
 
 void ArduinoCloudPropertyContainer::appendChangedProperties(CborEncoder * arrayEncoder) {
-  appendChangedProperties<bool>  (_bool_property_list,   arrayEncoder);
-  appendChangedProperties<int>   (_int_property_list,    arrayEncoder);
+  appendChangedProperties<bool> (_bool_property_list,   arrayEncoder);
+  appendChangedProperties<int> (_int_property_list,    arrayEncoder);
   appendChangedProperties<float> (_float_property_list,  arrayEncoder);
   appendChangedProperties<String>(_string_property_list, arrayEncoder);
 }

--- a/src/ArduinoCloudPropertyContainer.hpp
+++ b/src/ArduinoCloudPropertyContainer.hpp
@@ -19,7 +19,7 @@
 #define ARDUINO_CLOUD_PROPERTY_CONTAINER_NEW_H_
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include "ArduinoCloudProperty.hpp"
@@ -28,53 +28,69 @@
 #include "lib/LinkedList/LinkedList.h"
 
 /******************************************************************************
- * CLASS DECLARATION
+   CLASS DECLARATION
  ******************************************************************************/
 
 class ArduinoCloudPropertyContainer {
-public:
+  public:
 
-  bool isPropertyInContainer    (Type const type, String const & name);
-  int  getNumOfChangedProperties();
-  int  updateTimestampOnChangedProperties(unsigned long changeEventTime);
-  void appendChangedProperties  (CborEncoder * arrayEncoder);
+    bool isPropertyInContainer(Type const type, String const & name);
+    int  getNumOfChangedProperties();
+    int  updateTimestampOnChangedProperties(unsigned long changeEventTime);
+    void appendChangedProperties(CborEncoder * arrayEncoder);
 
-  inline ArduinoCloudProperty<bool>   * getPropertyBool  (String const & name) { return getProperty(_bool_property_list,   name); }
-  inline ArduinoCloudProperty<int>    * getPropertyInt   (String const & name) { return getProperty(_int_property_list,    name); }
-  inline ArduinoCloudProperty<float>  * getPropertyFloat (String const & name) { return getProperty(_float_property_list,  name); }
-  inline ArduinoCloudProperty<String> * getPropertyString(String const & name) { return getProperty(_string_property_list, name); }
+    inline ArduinoCloudProperty<bool>   * getPropertyBool(String const & name) {
+      return getProperty(_bool_property_list,   name);
+    }
+    inline ArduinoCloudProperty<int>    * getPropertyInt(String const & name) {
+      return getProperty(_int_property_list,    name);
+    }
+    inline ArduinoCloudProperty<float>  * getPropertyFloat(String const & name) {
+      return getProperty(_float_property_list,  name);
+    }
+    inline ArduinoCloudProperty<String> * getPropertyString(String const & name) {
+      return getProperty(_string_property_list, name);
+    }
 
-  inline void addProperty(ArduinoCloudProperty<bool>   * property_obj) { _bool_property_list.add  (property_obj); }
-  inline void addProperty(ArduinoCloudProperty<int>    * property_obj) { _int_property_list.add   (property_obj); }
-  inline void addProperty(ArduinoCloudProperty<float>  * property_obj) { _float_property_list.add (property_obj); }
-  inline void addProperty(ArduinoCloudProperty<String> * property_obj) { _string_property_list.add(property_obj); }
+    inline void addProperty(ArduinoCloudProperty<bool>   * property_obj) {
+      _bool_property_list.add(property_obj);
+    }
+    inline void addProperty(ArduinoCloudProperty<int>    * property_obj) {
+      _int_property_list.add(property_obj);
+    }
+    inline void addProperty(ArduinoCloudProperty<float>  * property_obj) {
+      _float_property_list.add(property_obj);
+    }
+    inline void addProperty(ArduinoCloudProperty<String> * property_obj) {
+      _string_property_list.add(property_obj);
+    }
 
-private:
+  private:
 
-  LinkedList<ArduinoCloudProperty<bool>   *> _bool_property_list;
-  LinkedList<ArduinoCloudProperty<int>    *> _int_property_list;
-  LinkedList<ArduinoCloudProperty<float>  *> _float_property_list;
-  LinkedList<ArduinoCloudProperty<String> *> _string_property_list;
+    LinkedList<ArduinoCloudProperty<bool>   *> _bool_property_list;
+    LinkedList<ArduinoCloudProperty<int>    *> _int_property_list;
+    LinkedList<ArduinoCloudProperty<float>  *> _float_property_list;
+    LinkedList<ArduinoCloudProperty<String> *> _string_property_list;
 
-  template <typename T>
-  bool isPropertyInList(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name);
+    template <typename T>
+    bool isPropertyInList(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name);
 
-  template <typename T>
-  ArduinoCloudProperty<T> * getProperty(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name);
+    template <typename T>
+    ArduinoCloudProperty<T> * getProperty(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name);
 
-  template <typename T>
-  int getNumOfChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list);
-  
-  template <typename T>
-  int updateTimestampOnChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, unsigned long changeEventTime);
+    template <typename T>
+    int getNumOfChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list);
 
-  template <typename T>
-  void appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder);
+    template <typename T>
+    int updateTimestampOnChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, unsigned long changeEventTime);
+
+    template <typename T>
+    void appendChangedProperties(LinkedList<ArduinoCloudProperty<T> *> & list, CborEncoder * arrayEncoder);
 
 };
 
 /******************************************************************************
- * TEMPLATE IMPLEMENTATION
+   TEMPLATE IMPLEMENTATION
  ******************************************************************************/
 
 #include "ArduinoCloudPropertyContainer.ipp"

--- a/src/ArduinoCloudPropertyContainer.ipp
+++ b/src/ArduinoCloudPropertyContainer.ipp
@@ -16,14 +16,16 @@
 //
 
 /******************************************************************************
- * PRIVATE MEMBER FUNCTIONS
+   PRIVATE MEMBER FUNCTIONS
  ******************************************************************************/
 
 template <typename T>
 bool ArduinoCloudPropertyContainer::isPropertyInList(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name) {
   for (int i = 0; i < list.size(); i++) {
     ArduinoCloudProperty<T> * p = list.get(i);
-    if (p->name() == name) return true;
+    if (p->name() == name) {
+      return true;
+    }
   }
   return false;
 }
@@ -32,7 +34,9 @@ template <typename T>
 ArduinoCloudProperty<T> * ArduinoCloudPropertyContainer::getProperty(LinkedList<ArduinoCloudProperty<T> *> & list, String const & name) {
   for (int i = 0; i < list.size(); i++) {
     ArduinoCloudProperty<T> * p = list.get(i);
-    if (p->name() == name) return p;
+    if (p->name() == name) {
+      return p;
+    }
   }
   return 0;
 }

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -192,8 +192,8 @@ void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const lengt
       case MapParserState::StringValue  : next_state = handle_StringValue(&value_iter, &map_data); break;
       case MapParserState::BooleanValue : next_state = handle_BooleanValue(&value_iter, &map_data); break;
       case MapParserState::LeaveMap     : next_state = handle_LeaveMap(&map_iter, &value_iter, &map_data); break;
-      case MapParserState::Complete     : /* Nothing to do */                                                   break;
-      case MapParserState::Error        : return;                                                               break;
+      case MapParserState::Complete     : /* Nothing to do */ break;
+      case MapParserState::Error        : return; break;
     }
 
     current_state = next_state;

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -16,7 +16,7 @@
 //
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include <Arduino.h>
@@ -26,53 +26,52 @@
 #include <math.h>
 
 /******************************************************************************
- * DEBUG FUNCTIONS
+   DEBUG FUNCTIONS
  ******************************************************************************/
 
 #if defined(DEBUG_MEMORY) && defined(ARDUINO_ARCH_SAMD)
 extern "C" char *sbrk(int i);
-void PrintFreeRam (void)
-{
-    char stack_dummy = 0;
-    Serial.print("Free RAM: "); Serial.println(&stack_dummy - sbrk(0));
+void PrintFreeRam(void) {
+  char stack_dummy = 0;
+  Serial.print("Free RAM: "); Serial.println(&stack_dummy - sbrk(0));
 }
 #endif
 
 #ifdef ARDUINO_ARCH_SAMD
 static void utox8(uint32_t val, char* s) {
-    for (int i = 0; i < 8; i++) {
-        int d = val & 0XF;
-        val = (val >> 4);
-        s[7 - i] = d > 9 ? 'A' + d - 10 : '0' + d;
-    }
+  for (int i = 0; i < 8; i++) {
+    int d = val & 0XF;
+    val = (val >> 4);
+    s[7 - i] = d > 9 ? 'A' + d - 10 : '0' + d;
+  }
 }
 #endif
 
 #ifdef ARDUINO_ARCH_MRAA
-#define Serial DebugSerial
+  #define Serial DebugSerial
 #endif
 
 /******************************************************************************
- * CTOR/DTOR
+   CTOR/DTOR
  ******************************************************************************/
 
 ArduinoCloudThing::ArduinoCloudThing() {
-#ifdef ARDUINO_ARCH_SAMD
-    #define SERIAL_NUMBER_WORD_0    *(volatile uint32_t*)(0x0080A00C)
-    #define SERIAL_NUMBER_WORD_1    *(volatile uint32_t*)(0x0080A040)
-    #define SERIAL_NUMBER_WORD_2    *(volatile uint32_t*)(0x0080A044)
-    #define SERIAL_NUMBER_WORD_3    *(volatile uint32_t*)(0x0080A048)
+  #ifdef ARDUINO_ARCH_SAMD
+#define SERIAL_NUMBER_WORD_0    *(volatile uint32_t*)(0x0080A00C)
+#define SERIAL_NUMBER_WORD_1    *(volatile uint32_t*)(0x0080A040)
+#define SERIAL_NUMBER_WORD_2    *(volatile uint32_t*)(0x0080A044)
+#define SERIAL_NUMBER_WORD_3    *(volatile uint32_t*)(0x0080A048)
 
-    utox8(SERIAL_NUMBER_WORD_0, &_uuid[0]);
-    utox8(SERIAL_NUMBER_WORD_1, &_uuid[8]);
-    utox8(SERIAL_NUMBER_WORD_2, &_uuid[16]);
-    utox8(SERIAL_NUMBER_WORD_3, &_uuid[24]);
-    _uuid[32] = '\0';
-#endif
+  utox8(SERIAL_NUMBER_WORD_0, &_uuid[0]);
+  utox8(SERIAL_NUMBER_WORD_1, &_uuid[8]);
+  utox8(SERIAL_NUMBER_WORD_2, &_uuid[16]);
+  utox8(SERIAL_NUMBER_WORD_3, &_uuid[24]);
+  _uuid[32] = '\0';
+  #endif
 }
 
 /******************************************************************************
- * PUBLIC MEMBER FUNCTIONS
+   PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
 
 void ArduinoCloudThing::begin() {
@@ -88,37 +87,35 @@ int ArduinoCloudThing::encode(uint8_t * data, size_t const size) {
   // time interval may be elapsed or property may be changed
   int const num_changed_properties = _property_cont.getNumOfChangedProperties();
 
-  if(num_changed_properties > 0) {
+  if (num_changed_properties > 0) {
     CborEncoder encoder, arrayEncoder;
 
     cbor_encoder_init(&encoder, data, size, 0);
 
-    if(cbor_encoder_create_array(&encoder, &arrayEncoder, num_changed_properties) != CborNoError) {
+    if (cbor_encoder_create_array(&encoder, &arrayEncoder, num_changed_properties) != CborNoError) {
       return -1;
     }
 
     _property_cont.appendChangedProperties(&arrayEncoder);
 
-    if(cbor_encoder_close_container(&encoder, &arrayEncoder) != CborNoError) {
+    if (cbor_encoder_close_container(&encoder, &arrayEncoder) != CborNoError) {
       return -1;
     }
 
-#if defined(DEBUG_MEMORY) && defined(ARDUINO_ARCH_SAMD)
-PrintFreeRam();
-#endif
+    #if defined(DEBUG_MEMORY) && defined(ARDUINO_ARCH_SAMD)
+    PrintFreeRam();
+    #endif
     int const bytes_encoded = cbor_encoder_get_buffer_size(&encoder, data);
     return bytes_encoded;
-  }
-  else {
+  } else {
     return num_changed_properties;
   }
 }
 
 ArduinoCloudProperty<bool> & ArduinoCloudThing::addPropertyReal(bool & property, String const & name, Permission const permission) {
-  if(_property_cont.isPropertyInContainer(Type::Bool, name)) {
+  if (_property_cont.isPropertyInContainer(Type::Bool, name)) {
     return (*_property_cont.getPropertyBool(name));
-  }
-  else {
+  } else {
     ArduinoCloudProperty<bool> *property_opj = new ArduinoCloudProperty<bool>(property, name, permission);
     _property_cont.addProperty(property_opj);
     return (*property_opj);
@@ -126,10 +123,9 @@ ArduinoCloudProperty<bool> & ArduinoCloudThing::addPropertyReal(bool & property,
 }
 
 ArduinoCloudProperty<int> & ArduinoCloudThing::addPropertyReal(int & property, String const & name, Permission const permission) {
-  if(_property_cont.isPropertyInContainer(Type::Int, name)) {
+  if (_property_cont.isPropertyInContainer(Type::Int, name)) {
     return (*_property_cont.getPropertyInt(name));
-  }
-  else {
+  } else {
     ArduinoCloudProperty<int> * property_opj = new ArduinoCloudProperty<int>(property, name, permission);
     _property_cont.addProperty(property_opj);
     return (*property_opj);
@@ -137,10 +133,9 @@ ArduinoCloudProperty<int> & ArduinoCloudThing::addPropertyReal(int & property, S
 }
 
 ArduinoCloudProperty<float> & ArduinoCloudThing::addPropertyReal(float & property, String const & name, Permission const permission) {
-  if(_property_cont.isPropertyInContainer(Type::Float, name)) {
+  if (_property_cont.isPropertyInContainer(Type::Float, name)) {
     return (*_property_cont.getPropertyFloat(name));
-  }
-  else {
+  } else {
     ArduinoCloudProperty<float> * property_opj = new ArduinoCloudProperty<float>(property, name, permission);
     _property_cont.addProperty(property_opj);
     return (*property_opj);
@@ -148,10 +143,9 @@ ArduinoCloudProperty<float> & ArduinoCloudThing::addPropertyReal(float & propert
 }
 
 ArduinoCloudProperty<String> & ArduinoCloudThing::addPropertyReal(String & property, String const & name, Permission const permission) {
-  if(_property_cont.isPropertyInContainer(Type::String, name)) {
+  if (_property_cont.isPropertyInContainer(Type::String, name)) {
     return (*_property_cont.getPropertyString(name));
-  }
-  else {
+  } else {
     ArduinoCloudProperty<String> * property_opj = new ArduinoCloudProperty<String>(property, name, permission);
     _property_cont.addProperty(property_opj);
     return (*property_opj);
@@ -167,36 +161,39 @@ void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const lengt
              map_iter,
              value_iter;
 
-  if(cbor_parser_init(payload, length, 0, &parser, &array_iter) != CborNoError)
+  if (cbor_parser_init(payload, length, 0, &parser, &array_iter) != CborNoError) {
     return;
+  }
 
-  if(array_iter.type != CborArrayType)
+  if (array_iter.type != CborArrayType) {
     return;
+  }
 
-  if(cbor_value_enter_container(&array_iter, &map_iter) != CborNoError)
+  if (cbor_value_enter_container(&array_iter, &map_iter) != CborNoError) {
     return;
+  }
 
   CborMapData    map_data;
   MapParserState current_state = MapParserState::EnterMap,
                  next_state;
 
-  while(current_state != MapParserState::Complete) {
+  while (current_state != MapParserState::Complete) {
 
-    switch(current_state) {
-    case MapParserState::EnterMap     : next_state = handle_EnterMap     (&map_iter, &value_iter, &map_data); break;
-    case MapParserState::MapKey       : next_state = handle_MapKey       (&value_iter                      ); break;
-    case MapParserState::UndefinedKey : next_state = handle_UndefinedKey (&value_iter                      ); break;
-    case MapParserState::BaseVersion  : next_state = handle_BaseVersion  (&value_iter, &map_data           ); break;
-    case MapParserState::BaseName     : next_state = handle_BaseName     (&value_iter, &map_data           ); break;
-    case MapParserState::BaseTime     : next_state = handle_BaseTime     (&value_iter, &map_data           ); break;
-    case MapParserState::Time         : next_state = handle_Time         (&value_iter, &map_data           ); break;
-    case MapParserState::Name         : next_state = handle_Name         (&value_iter, &map_data           ); break;
-    case MapParserState::Value        : next_state = handle_Value        (&value_iter, &map_data           ); break;
-    case MapParserState::StringValue  : next_state = handle_StringValue  (&value_iter, &map_data           ); break;
-    case MapParserState::BooleanValue : next_state = handle_BooleanValue (&value_iter, &map_data           ); break;
-    case MapParserState::LeaveMap     : next_state = handle_LeaveMap     (&map_iter, &value_iter, &map_data); break;
-    case MapParserState::Complete     : /* Nothing to do */                                                   break;
-    case MapParserState::Error        : return;                                                               break;
+    switch (current_state) {
+      case MapParserState::EnterMap     : next_state = handle_EnterMap(&map_iter, &value_iter, &map_data); break;
+      case MapParserState::MapKey       : next_state = handle_MapKey(&value_iter); break;
+      case MapParserState::UndefinedKey : next_state = handle_UndefinedKey(&value_iter); break;
+      case MapParserState::BaseVersion  : next_state = handle_BaseVersion(&value_iter, &map_data); break;
+      case MapParserState::BaseName     : next_state = handle_BaseName(&value_iter, &map_data); break;
+      case MapParserState::BaseTime     : next_state = handle_BaseTime(&value_iter, &map_data); break;
+      case MapParserState::Time         : next_state = handle_Time(&value_iter, &map_data); break;
+      case MapParserState::Name         : next_state = handle_Name(&value_iter, &map_data); break;
+      case MapParserState::Value        : next_state = handle_Value(&value_iter, &map_data); break;
+      case MapParserState::StringValue  : next_state = handle_StringValue(&value_iter, &map_data); break;
+      case MapParserState::BooleanValue : next_state = handle_BooleanValue(&value_iter, &map_data); break;
+      case MapParserState::LeaveMap     : next_state = handle_LeaveMap(&map_iter, &value_iter, &map_data); break;
+      case MapParserState::Complete     : /* Nothing to do */                                                   break;
+      case MapParserState::Error        : return;                                                               break;
     }
 
     current_state = next_state;
@@ -204,14 +201,14 @@ void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const lengt
 }
 
 /******************************************************************************
- * PRIVATE MEMBER FUNCTIONS
+   PRIVATE MEMBER FUNCTIONS
  ******************************************************************************/
 
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_EnterMap(CborValue * map_iter, CborValue * value_iter, CborMapData * map_data) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_get_type(map_iter) == CborMapType) {
-    if(cbor_value_enter_container(map_iter, value_iter) == CborNoError) {
+  if (cbor_value_get_type(map_iter) == CborMapType) {
+    if (cbor_value_enter_container(map_iter, value_iter) == CborNoError) {
       map_data->resetNotBase();
       next_state = MapParserState::MapKey;
     }
@@ -223,27 +220,37 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_EnterMap(CborValue *
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_MapKey(CborValue * value_iter) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_at_end(value_iter)) {
+  if (cbor_value_at_end(value_iter)) {
     next_state = MapParserState::LeaveMap;
   }
   /* The Map use the CBOR Label (protocol V2)
-   * Example [{0: "temperature", 2: 25}]
-   */
+     Example [{0: "temperature", 2: 25}]
+  */
   else if (cbor_value_is_integer(value_iter)) {
-	int val = 0;
-	if(cbor_value_get_int(value_iter, &val) == CborNoError) {
-	  if(cbor_value_advance(value_iter) == CborNoError) {
-		if     (val == static_cast<int>(CborIntegerMapKey::Name        )) next_state = MapParserState::Name;
-		else if(val == static_cast<int>(CborIntegerMapKey::BaseVersion )) next_state = MapParserState::BaseVersion;
-		else if(val == static_cast<int>(CborIntegerMapKey::BaseName    )) next_state = MapParserState::BaseName;
-		else if(val == static_cast<int>(CborIntegerMapKey::BaseTime    )) next_state = MapParserState::BaseTime;
-		else if(val == static_cast<int>(CborIntegerMapKey::Value       )) next_state = MapParserState::Value;
-		else if(val == static_cast<int>(CborIntegerMapKey::StringValue )) next_state = MapParserState::StringValue;
-		else if(val == static_cast<int>(CborIntegerMapKey::BooleanValue)) next_state = MapParserState::BooleanValue;
-		else if(val == static_cast<int>(CborIntegerMapKey::Time        )) next_state = MapParserState::Time;
-		else                                                              next_state = MapParserState::UndefinedKey;
-	  }
-	}
+    int val = 0;
+    if (cbor_value_get_int(value_iter, &val) == CborNoError) {
+      if (cbor_value_advance(value_iter) == CborNoError) {
+        if (val == static_cast<int>(CborIntegerMapKey::Name)) {
+          next_state = MapParserState::Name;
+        } else if (val == static_cast<int>(CborIntegerMapKey::BaseVersion)) {
+          next_state = MapParserState::BaseVersion;
+        } else if (val == static_cast<int>(CborIntegerMapKey::BaseName)) {
+          next_state = MapParserState::BaseName;
+        } else if (val == static_cast<int>(CborIntegerMapKey::BaseTime)) {
+          next_state = MapParserState::BaseTime;
+        } else if (val == static_cast<int>(CborIntegerMapKey::Value)) {
+          next_state = MapParserState::Value;
+        } else if (val == static_cast<int>(CborIntegerMapKey::StringValue)) {
+          next_state = MapParserState::StringValue;
+        } else if (val == static_cast<int>(CborIntegerMapKey::BooleanValue)) {
+          next_state = MapParserState::BooleanValue;
+        } else if (val == static_cast<int>(CborIntegerMapKey::Time)) {
+          next_state = MapParserState::Time;
+        } else {
+          next_state = MapParserState::UndefinedKey;
+        }
+      }
+    }
   }
 
   return next_state;
@@ -252,7 +259,7 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_MapKey(CborValue * v
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_UndefinedKey(CborValue * value_iter) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_advance(value_iter) == CborNoError) {
+  if (cbor_value_advance(value_iter) == CborNoError) {
     next_state = MapParserState::MapKey;
   }
 
@@ -262,12 +269,12 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_UndefinedKey(CborVal
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BaseVersion(CborValue * value_iter, CborMapData * map_data) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_is_integer(value_iter)) {
+  if (cbor_value_is_integer(value_iter)) {
     int val = 0;
-    if(cbor_value_get_int(value_iter, &val) == CborNoError) {
+    if (cbor_value_get_int(value_iter, &val) == CborNoError) {
       map_data->base_version.set(val);
 
-      if(cbor_value_advance(value_iter) == CborNoError) {
+      if (cbor_value_advance(value_iter) == CborNoError) {
         next_state = MapParserState::MapKey;
       }
     }
@@ -279,10 +286,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BaseVersion(CborValu
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BaseName(CborValue * value_iter, CborMapData * map_data) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_is_text_string(value_iter)) {
+  if (cbor_value_is_text_string(value_iter)) {
     char * val      = 0;
     size_t val_size = 0;
-    if(cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
+    if (cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
       map_data->base_name.set(String(val));
       free(val);
       next_state = MapParserState::MapKey;
@@ -296,10 +303,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BaseTime(CborValue *
   MapParserState next_state = MapParserState::Error;
 
   double val = 0.0;
-  if(ifNumericConvertToDouble(value_iter, &val)) {
+  if (ifNumericConvertToDouble(value_iter, &val)) {
     map_data->base_time.set(val);
 
-    if(cbor_value_advance(value_iter) == CborNoError) {
+    if (cbor_value_advance(value_iter) == CborNoError) {
       next_state = MapParserState::MapKey;
     }
   }
@@ -310,10 +317,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BaseTime(CborValue *
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * value_iter, CborMapData * map_data) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_is_text_string(value_iter)) {
+  if (cbor_value_is_text_string(value_iter)) {
     char * val      = 0;
     size_t val_size = 0;
-    if(cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
+    if (cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
       map_data->name.set(val);
       free(val);
       next_state = MapParserState::MapKey;
@@ -327,10 +334,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Value(CborValue * va
   MapParserState next_state = MapParserState::Error;
 
   double val = 0.0;
-  if(ifNumericConvertToDouble(value_iter, &val)) {
+  if (ifNumericConvertToDouble(value_iter, &val)) {
     map_data->val.set(val);
 
-    if(cbor_value_advance(value_iter) == CborNoError) {
+    if (cbor_value_advance(value_iter) == CborNoError) {
       next_state = MapParserState::MapKey;
     }
   }
@@ -341,10 +348,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Value(CborValue * va
 ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_StringValue(CborValue * value_iter, CborMapData * map_data) {
   MapParserState next_state = MapParserState::Error;
 
-  if(cbor_value_is_text_string(value_iter)) {
+  if (cbor_value_is_text_string(value_iter)) {
     char * val      = 0;
     size_t val_size = 0;
-    if(cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
+    if (cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
       map_data->str_val.set(String(val));
       free(val);
       next_state = MapParserState::MapKey;
@@ -358,10 +365,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_BooleanValue(CborVal
   MapParserState next_state = MapParserState::Error;
 
   bool val = false;
-  if(cbor_value_get_boolean(value_iter, &val) == CborNoError) {
+  if (cbor_value_get_boolean(value_iter, &val) == CborNoError) {
     map_data->bool_val.set(val);
 
-    if(cbor_value_advance(value_iter) == CborNoError) {
+    if (cbor_value_advance(value_iter) == CborNoError) {
       next_state = MapParserState::MapKey;
     }
   }
@@ -373,10 +380,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Time(CborValue * val
   MapParserState next_state = MapParserState::Error;
 
   double val = 0.0;
-  if(ifNumericConvertToDouble(value_iter, &val)) {
+  if (ifNumericConvertToDouble(value_iter, &val)) {
     map_data->time.set(val);
 
-    if(cbor_value_advance(value_iter) == CborNoError) {
+    if (cbor_value_advance(value_iter) == CborNoError) {
       next_state = MapParserState::MapKey;
     }
   }
@@ -389,23 +396,22 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
 
   //compute the cloud event change time
   unsigned long cloudChangeEventTime = 0;
-  if(map_data->base_time.isSet()){
+  if (map_data->base_time.isSet()) {
     cloudChangeEventTime = (unsigned long)(map_data->base_time.get());
   }
-  if(map_data->time.isSet()){
+  if (map_data->time.isSet()) {
     cloudChangeEventTime += (unsigned long)map_data->time.get();
   }
   /* Update the property containers depending on the parsed data */
 
-  if(map_data->name.isSet())
-  {
+  if (map_data->name.isSet()) {
     /* Value (Integer/Float/Double/Half-Float) */
-    if(map_data->val.isSet()) {
-      ArduinoCloudProperty<int>   * int_property   = _property_cont.getPropertyInt  (map_data->name.get());
+    if (map_data->val.isSet()) {
+      ArduinoCloudProperty<int>   * int_property   = _property_cont.getPropertyInt(map_data->name.get());
       ArduinoCloudProperty<float> * float_property = _property_cont.getPropertyFloat(map_data->name.get());
 
-      if(int_property && int_property->isWriteableByCloud()) {
-        if(_syncMessage) {
+      if (int_property && int_property->isWriteableByCloud()) {
+        if (_syncMessage) {
           int_property->setLastCloudChangeTimestamp(cloudChangeEventTime);
           int_property->setCloudShadowValue(map_data->val.get());
           int_property->execCallbackOnSync();
@@ -415,8 +421,8 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
         }
       }
 
-      if(float_property && float_property->isWriteableByCloud()) {
-        if(_syncMessage) {
+      if (float_property && float_property->isWriteableByCloud()) {
+        if (_syncMessage) {
           float_property->setLastCloudChangeTimestamp(cloudChangeEventTime);
           float_property->setCloudShadowValue(map_data->val.get());
           float_property->execCallbackOnSync();
@@ -428,10 +434,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
     }
 
     /* Value (String) */
-    if(map_data->str_val.isSet()) {
+    if (map_data->str_val.isSet()) {
       ArduinoCloudProperty<String>* string_property = _property_cont.getPropertyString(map_data->name.get());
-      if(string_property && string_property->isWriteableByCloud()) {
-        if(_syncMessage) {
+      if (string_property && string_property->isWriteableByCloud()) {
+        if (_syncMessage) {
           string_property->setLastCloudChangeTimestamp(cloudChangeEventTime);
           string_property->setCloudShadowValue(map_data->str_val.get());
           string_property->execCallbackOnSync();
@@ -443,10 +449,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
     }
 
     /* Value (bool) */
-    if(map_data->bool_val.isSet()) {
+    if (map_data->bool_val.isSet()) {
       ArduinoCloudProperty<bool>* bool_property = _property_cont.getPropertyBool(map_data->name.get());
-      if(bool_property && bool_property->isWriteableByCloud()) {
-        if(_syncMessage) {
+      if (bool_property && bool_property->isWriteableByCloud()) {
+        if (_syncMessage) {
           bool_property->setLastCloudChangeTimestamp(cloudChangeEventTime);
           bool_property->setCloudShadowValue(map_data->bool_val.get());
           bool_property->execCallbackOnSync();
@@ -460,11 +466,10 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
 
   /* Transition into the next map if available, otherwise finish */
 
-  if(cbor_value_leave_container(map_iter, value_iter) == CborNoError) {
-    if(!cbor_value_at_end(map_iter)) {
+  if (cbor_value_leave_container(map_iter, value_iter) == CborNoError) {
+    if (!cbor_value_at_end(map_iter)) {
       next_state = MapParserState::EnterMap;
-    }
-    else {
+    } else {
       next_state = MapParserState::Complete;
     }
   }
@@ -474,30 +479,27 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_LeaveMap(CborValue *
 
 bool ArduinoCloudThing::ifNumericConvertToDouble(CborValue * value_iter, double * numeric_val) {
 
-  if(cbor_value_is_integer(value_iter)) {
+  if (cbor_value_is_integer(value_iter)) {
     int64_t val = 0;
-    if(cbor_value_get_int64(value_iter, &val) == CborNoError) {
+    if (cbor_value_get_int64(value_iter, &val) == CborNoError) {
       *numeric_val = static_cast<double>(val);
       return true;
     }
-  }
-  else if(cbor_value_is_double(value_iter)) {
+  } else if (cbor_value_is_double(value_iter)) {
     double val = 0.0;
-    if(cbor_value_get_double(value_iter, &val) == CborNoError) {
+    if (cbor_value_get_double(value_iter, &val) == CborNoError) {
       *numeric_val = val;
       return true;
     }
-  }
-  else if(cbor_value_is_float(value_iter)) {
+  } else if (cbor_value_is_float(value_iter)) {
     float val = 0.0;
-    if(cbor_value_get_float(value_iter, &val) == CborNoError) {
+    if (cbor_value_get_float(value_iter, &val) == CborNoError) {
       *numeric_val = static_cast<double>(val);
       return true;
     }
-  }
-  else if(cbor_value_is_half_float(value_iter)) {
+  } else if (cbor_value_is_half_float(value_iter)) {
     uint16_t val = 0;
-    if(cbor_value_get_half_float(value_iter, &val) == CborNoError) {
+    if (cbor_value_get_half_float(value_iter, &val) == CborNoError) {
       *numeric_val = static_cast<double>(convertCborHalfFloatToDouble(val));
       return true;
     }
@@ -511,8 +513,12 @@ double ArduinoCloudThing::convertCborHalfFloatToDouble(uint16_t const half_val) 
   int exp = (half_val >> 10) & 0x1f;
   int mant = half_val & 0x3ff;
   double val;
-  if (exp == 0) val = ldexp(mant, -24);
-  else if (exp != 31) val = ldexp(mant + 1024, exp - 25);
-  else val = mant == 0 ? INFINITY : NAN;
+  if (exp == 0) {
+    val = ldexp(mant, -24);
+  } else if (exp != 31) {
+    val = ldexp(mant + 1024, exp - 25);
+  } else {
+    val = mant == 0 ? INFINITY : NAN;
+  }
   return half_val & 0x8000 ? -val : val;
 }

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -19,7 +19,7 @@
 #define ARDUINO_CLOUD_THING_H_
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include "ArduinoCloudProperty.hpp"
@@ -28,7 +28,7 @@
 #include "lib/LinkedList/LinkedList.h"
 
 /******************************************************************************
- * CONSTANTS
+   CONSTANTS
  ******************************************************************************/
 
 static bool ON  = true;
@@ -41,13 +41,13 @@ static long const HOURS     = 3600;
 static long const DAYS      = 86400;
 
 /******************************************************************************
- * SYNCHRONIZATION CALLBACKS
+   SYNCHRONIZATION CALLBACKS
  ******************************************************************************/
 
 #define MOST_RECENT_WINS onAutoSync
 template<typename T>
 void onAutoSync(ArduinoCloudProperty<T> property) {
-  if( property.getLastCloudChangeTimestamp() > property.getLastLocalChangeTimestamp()){
+  if (property.getLastCloudChangeTimestamp() > property.getLastLocalChangeTimestamp()) {
     property.setPropertyValue(property.getCloudShadowValue());
     property.forceCallbackOnChange();
   }
@@ -66,108 +66,117 @@ void onForceDeviceSync(ArduinoCloudProperty<T> property) {
 }
 
 /******************************************************************************
- * CLASS DECLARATION
+   CLASS DECLARATION
  ******************************************************************************/
 
 class ArduinoCloudThing {
 
-public:
-  ArduinoCloudThing();
-
-  void begin();
-
-  ArduinoCloudProperty<bool>   & addPropertyReal(bool   & property, String const & name, Permission const permission);
-  ArduinoCloudProperty<int>    & addPropertyReal(int    & property, String const & name, Permission const permission);
-  ArduinoCloudProperty<float>  & addPropertyReal(float  & property, String const & name, Permission const permission);
-  ArduinoCloudProperty<String> & addPropertyReal(String & property, String const & name, Permission const permission);
-
-  // compute the timestamp of the local properties changes 
-  int updateTimestampOnChangedProperties(unsigned long changeEventTime);
-  /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
-  int encode(uint8_t * data, size_t const size);
-  int encode(ArduinoCloudPropertyContainer *property_cont, uint8_t * data, size_t const size);
-  /* decode a CBOR payload received from the cloud */
-  void decode(uint8_t const * const payload, size_t const length, bool syncMessage = false);
-
-
-private:
-
-  char                          _uuid[33];
-  ArduinoCloudPropertyContainer _property_cont;
-  bool                          _syncMessage;
-
-  enum class MapParserState {
-    EnterMap,
-    MapKey,
-    UndefinedKey,
-    BaseVersion,
-    BaseName,
-    BaseTime,
-    Name,
-    Value,
-    StringValue,
-    BooleanValue,
-    Time,
-    LeaveMap,
-    Complete,
-    Error
-  };
-
-  template <typename T>
-  class MapEntry {
   public:
+    ArduinoCloudThing();
 
-    MapEntry() : _is_set(false) { }
+    void begin();
 
-    inline void    set  (T const & entry) { _entry = entry; _is_set = true; }
-    inline T const get  () const { return _entry; }
+    ArduinoCloudProperty<bool>   & addPropertyReal(bool   & property, String const & name, Permission const permission);
+    ArduinoCloudProperty<int>    & addPropertyReal(int    & property, String const & name, Permission const permission);
+    ArduinoCloudProperty<float>  & addPropertyReal(float  & property, String const & name, Permission const permission);
+    ArduinoCloudProperty<String> & addPropertyReal(String & property, String const & name, Permission const permission);
 
-    inline bool    isSet() const { return _is_set; }
-    inline void    reset()       { _is_set = false; }
+    // compute the timestamp of the local properties changes
+    int updateTimestampOnChangedProperties(unsigned long changeEventTime);
+    /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
+    int encode(uint8_t * data, size_t const size);
+    int encode(ArduinoCloudPropertyContainer *property_cont, uint8_t * data, size_t const size);
+    /* decode a CBOR payload received from the cloud */
+    void decode(uint8_t const * const payload, size_t const length, bool syncMessage = false);
+
 
   private:
 
-    T    _entry;
-    bool _is_set;
+    char                          _uuid[33];
+    ArduinoCloudPropertyContainer _property_cont;
+    bool                          _syncMessage;
 
-  };
+    enum class MapParserState {
+      EnterMap,
+      MapKey,
+      UndefinedKey,
+      BaseVersion,
+      BaseName,
+      BaseTime,
+      Name,
+      Value,
+      StringValue,
+      BooleanValue,
+      Time,
+      LeaveMap,
+      Complete,
+      Error
+    };
 
-  class CborMapData {
+    template <typename T>
+    class MapEntry {
+      public:
 
-  public:
-    MapEntry<int>    base_version;
-    MapEntry<String> base_name;
-    MapEntry<double> base_time;
-    MapEntry<String> name;
-    MapEntry<float>  val;
-    MapEntry<String> str_val;
-    MapEntry<bool>   bool_val;
-    MapEntry<double> time;
-    
-    void resetNotBase() {
-      name.reset        ();
-      val.reset         ();
-      str_val.reset     ();
-      bool_val.reset    ();
-      time.reset        ();
-    }
-  };
+        MapEntry() : _is_set(false) { }
 
-  MapParserState handle_EnterMap     (CborValue * map_iter, CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_MapKey       (CborValue * value_iter);
-  MapParserState handle_UndefinedKey (CborValue * value_iter);
-  MapParserState handle_BaseVersion  (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_BaseName     (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_BaseTime     (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_Name         (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_Value        (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_StringValue  (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_BooleanValue (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_Time         (CborValue * value_iter, CborMapData * map_data);
-  MapParserState handle_LeaveMap     (CborValue * map_iter, CborValue * value_iter, CborMapData const * const map_data);
+        inline void    set(T const & entry) {
+          _entry = entry;
+          _is_set = true;
+        }
+        inline T const get() const {
+          return _entry;
+        }
 
-  static bool   ifNumericConvertToDouble    (CborValue * value_iter, double * numeric_val);
-  static double convertCborHalfFloatToDouble(uint16_t const half_val);
+        inline bool    isSet() const {
+          return _is_set;
+        }
+        inline void    reset()       {
+          _is_set = false;
+        }
+
+      private:
+
+        T    _entry;
+        bool _is_set;
+
+    };
+
+    class CborMapData {
+
+      public:
+        MapEntry<int>    base_version;
+        MapEntry<String> base_name;
+        MapEntry<double> base_time;
+        MapEntry<String> name;
+        MapEntry<float>  val;
+        MapEntry<String> str_val;
+        MapEntry<bool>   bool_val;
+        MapEntry<double> time;
+
+        void resetNotBase() {
+          name.reset();
+          val.reset();
+          str_val.reset();
+          bool_val.reset();
+          time.reset();
+        }
+    };
+
+    MapParserState handle_EnterMap(CborValue * map_iter, CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_MapKey(CborValue * value_iter);
+    MapParserState handle_UndefinedKey(CborValue * value_iter);
+    MapParserState handle_BaseVersion(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_BaseName(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_BaseTime(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_Name(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_Value(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_StringValue(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_BooleanValue(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_Time(CborValue * value_iter, CborMapData * map_data);
+    MapParserState handle_LeaveMap(CborValue * map_iter, CborValue * value_iter, CborMapData const * const map_data);
+
+    static bool   ifNumericConvertToDouble(CborValue * value_iter, double * numeric_val);
+    static double convertCborHalfFloatToDouble(uint16_t const half_val);
 
 };
 

--- a/test/include/Arduino.h
+++ b/test/include/Arduino.h
@@ -1,24 +1,24 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 #ifndef TEST_ARDUINO_H_
 #define TEST_ARDUINO_H_
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include <string>
 
 /******************************************************************************
- * TYPEDEF
+   TYPEDEF
  ******************************************************************************/
 
 typedef std::string String;
 
 /******************************************************************************
- * FUNCTION PROTOTYPES
+   FUNCTION PROTOTYPES
  ******************************************************************************/
 
 void          set_millis(unsigned long const millis);

--- a/test/include/TestUtil.h
+++ b/test/include/TestUtil.h
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 #ifndef INCLUDE_TESTUTIL_H_
 #define INCLUDE_TESTUTIL_H_
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <ArduinoCloudThing.h>
@@ -14,7 +14,7 @@
 #include <vector>
 
 /**************************************************************************************
- * PROTOTYPES
+   PROTOTYPES
  **************************************************************************************/
 
 std::vector<uint8_t> encode(ArduinoCloudThing & thing);

--- a/test/src/Arduino.cpp
+++ b/test/src/Arduino.cpp
@@ -1,29 +1,27 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /******************************************************************************
- * INCLUDE
+   INCLUDE
  ******************************************************************************/
 
 #include <Arduino.h>
 
 /******************************************************************************
- * GLOBAL VARIABLES
+   GLOBAL VARIABLES
  ******************************************************************************/
 
 static unsigned long current_millis = 0;
 
 /******************************************************************************
- * PUBLIC FUNCTIONS
+   PUBLIC FUNCTIONS
  ******************************************************************************/
 
-void set_millis(unsigned long const millis)
-{
+void set_millis(unsigned long const millis) {
   current_millis = millis;
 }
 
-unsigned long millis()
-{
+unsigned long millis() {
   return current_millis;
 }

--- a/test/src/TestUtil.cpp
+++ b/test/src/TestUtil.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <TestUtil.h>
@@ -12,20 +12,17 @@
 #include <iostream>
 
 /**************************************************************************************
- * PUBLIC FUNCTIONS
+   PUBLIC FUNCTIONS
  **************************************************************************************/
 
-std::vector<uint8_t> encode(ArduinoCloudThing & thing)
-{
+std::vector<uint8_t> encode(ArduinoCloudThing & thing) {
   uint8_t buf[200] = {0};
   int const bytes_buf = thing.encode(buf, 200);
   return std::vector<uint8_t>(buf, buf + bytes_buf);
 }
 
-void print(std::vector<uint8_t> const & vect)
-{
-  for(auto i = vect.begin(); i != vect.end(); i++)
-  {
+void print(std::vector<uint8_t> const & vect) {
+  for (auto i = vect.begin(); i != vect.end(); i++) {
     std::cout << std::uppercase
               << std::hex
               << std::setw(2)

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE/MAIN
+   INCLUDE/MAIN
  **************************************************************************************/
 
 #define CATCH_CONFIG_MAIN

--- a/test/src/test_addPropertyReal.cpp
+++ b/test/src/test_addPropertyReal.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -11,13 +11,11 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("The same arduino cloud properties are added multiple times", "[ArduinoCloudThing::addPropertyReal]")
-{
-  WHEN("The same bool property is added multiple times")
-  {
+SCENARIO("The same arduino cloud properties are added multiple times", "[ArduinoCloudThing::addPropertyReal]") {
+  WHEN("The same bool property is added multiple times") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -25,16 +23,14 @@ SCENARIO("The same arduino cloud properties are added multiple times", "[Arduino
 
     ArduinoCloudProperty<bool> * bool_property_ptr_1 = &thing.addPropertyReal(bool_property, "bool_property", Permission::ReadWrite);
     ArduinoCloudProperty<bool> * bool_property_ptr_2 = &thing.addPropertyReal(bool_property, "bool_property", Permission::ReadWrite);
-    THEN("No new property is added and the first added property is returned instead of a new one")
-    {
-      REQUIRE(bool_property_ptr_1 == bool_property_ptr_2);      
+    THEN("No new property is added and the first added property is returned instead of a new one") {
+      REQUIRE(bool_property_ptr_1 == bool_property_ptr_2);
     }
   }
 
   /**************************************************************************************/
 
-  WHEN("the same int property is added multiple times")
-  {
+  WHEN("the same int property is added multiple times") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -43,16 +39,14 @@ SCENARIO("The same arduino cloud properties are added multiple times", "[Arduino
     ArduinoCloudProperty<int> * int_property_ptr_1 = &thing.addPropertyReal(int_property, "int_property", Permission::ReadWrite);
     ArduinoCloudProperty<int> * int_property_ptr_2 = &thing.addPropertyReal(int_property, "int_property", Permission::ReadWrite);
 
-    THEN("No new property is added and the first added property is returned instead of a new one")
-    {
+    THEN("No new property is added and the first added property is returned instead of a new one") {
       REQUIRE(int_property_ptr_1 == int_property_ptr_2);
     }
   }
 
   /**************************************************************************************/
 
-  WHEN("the same float property is added multiple times")
-  {
+  WHEN("the same float property is added multiple times") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -60,17 +54,15 @@ SCENARIO("The same arduino cloud properties are added multiple times", "[Arduino
 
     ArduinoCloudProperty<float> * float_property_ptr_1 = &thing.addPropertyReal(float_property, "float_property", Permission::ReadWrite);
     ArduinoCloudProperty<float> * float_property_ptr_2 = &thing.addPropertyReal(float_property, "float_property", Permission::ReadWrite);
-    
-    THEN("No new property is added and the first added property is returned instead of a new one")
-    {
+
+    THEN("No new property is added and the first added property is returned instead of a new one") {
       REQUIRE(float_property_ptr_1 == float_property_ptr_2);
     }
   }
 
   /**************************************************************************************/
 
-  WHEN("the same String property is added multiple times")
-  {
+  WHEN("the same String property is added multiple times") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -78,9 +70,8 @@ SCENARIO("The same arduino cloud properties are added multiple times", "[Arduino
 
     ArduinoCloudProperty<String> * str_property_ptr_1 = &thing.addPropertyReal(str_property, "str_property", Permission::ReadWrite);
     ArduinoCloudProperty<String> * str_property_ptr_2 = &thing.addPropertyReal(str_property, "str_property", Permission::ReadWrite);
-    
-    THEN("No new property is added and the first added property is returned instead of a new one")
-    {
+
+    THEN("No new property is added and the first added property is returned instead of a new one") {
       REQUIRE(str_property_ptr_1 == str_property_ptr_2);
     }
   }

--- a/test/src/test_callback.cpp
+++ b/test/src/test_callback.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,36 +12,32 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * GLOBAL CONSTANTS
+   GLOBAL CONSTANTS
  **************************************************************************************/
 
 static bool callback_called_protocol_v1 = false;
 static bool callback_called_protocol_v2 = false;
 
 /**************************************************************************************
- * TEST HELPER FUNCTIONS
+   TEST HELPER FUNCTIONS
  **************************************************************************************/
 
-void externalCallbackV1()
-{
+void externalCallbackV1() {
   callback_called_protocol_v1 = true;
 }
 
-void externalCallbackV2()
-{
+void externalCallbackV2() {
   callback_called_protocol_v2 = true;
 }
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A callback is registered via 'onUpdate' to be called on property change", "[ArduinoCloudThing::decode]")
-{
+SCENARIO("A callback is registered via 'onUpdate' to be called on property change", "[ArduinoCloudThing::decode]") {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V2")
-  {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -50,7 +46,7 @@ SCENARIO("A callback is registered via 'onUpdate' to be called on property chang
 
     /* [{0: "test", 2: 7}] = 81 A2 00 64 74 65 73 74 02 07 */
     uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x07};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length);
 
     REQUIRE(callback_called_protocol_v2 == true);
@@ -64,16 +60,13 @@ SCENARIO("A callback is registered via 'onUpdate' to be called on property chang
 static bool switch_turned_on       = false;
 static bool switch_callback_called = false;
 
-void switch_callback()
-{
+void switch_callback() {
   switch_turned_on       = false;
   switch_callback_called = true;
 }
 
-SCENARIO("A (boolean) property is manipulated in the callback to its origin state", "[ArduinoCloudThing::decode]")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("A (boolean) property is manipulated in the callback to its origin state", "[ArduinoCloudThing::decode]") {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
     encode(thing);
@@ -82,15 +75,15 @@ SCENARIO("A (boolean) property is manipulated in the callback to its origin stat
 
     /* [{0: "switch_turned_on", 4: true}] = 81 A2 00 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 04 F5 */
     uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length);
 
     REQUIRE(switch_callback_called == true);
 
     /* Since the property was reset to its origin state in the callback we
-     * expect that on the next call to encode this change is propagated to
-     * the cloud.
-     */
+       expect that on the next call to encode this change is propagated to
+       the cloud.
+    */
 
     /* [{0: "switch_turned_on", 4: false}] = 81 BF 00 70 73 77 69 74 63 68 5F 74 75 72 6E 65 64 5F 6F 6E 04 F4 FF */
     std::vector<uint8_t> const expected = {0x81, 0xBF, 0x00, 0x70, 0x73, 0x77, 0x69, 0x74, 0x63, 0x68, 0x5F, 0x74, 0x75, 0x72, 0x6E, 0x65, 0x64, 0x5F, 0x6F, 0x6E, 0x04, 0xF4, 0xFF};
@@ -106,21 +99,17 @@ static bool sync_callback_called = false;
 static bool change_callback_called = false;
 
 
-void auto_sync_callback(ArduinoCloudProperty<bool> property)
-{
+void auto_sync_callback(ArduinoCloudProperty<bool> property) {
   MOST_RECENT_WINS(property);
   sync_callback_called = true;
 }
 
-void change_callback()
-{
+void change_callback() {
   change_callback_called = true;
 }
 
-SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the AUTO_SYNC policy (the most recent value between the local one and the cloud one is finally assigned to the property). The onUpdate function is called if the cloud value is the most recent one. In this scenario the most updated value is the cloud one.")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the AUTO_SYNC policy (the most recent value between the local one and the cloud one is finally assigned to the property). The onUpdate function is called if the cloud value is the most recent one. In this scenario the most updated value is the cloud one.") {
+  GIVEN("CloudProtocol::V2") {
     test = false;
     sync_callback_called = false;
     change_callback_called = false;
@@ -133,8 +122,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
     thing.updateTimestampOnChangedProperties(1550138809);
 
     /* [{-3: 1550138810.00, 0: "test", 4: true}] = 81 A3 22 FB 41 D7 19 4F 6E 80 00 00 00 64 74 65 73 74 04 F5 */
-    uint8_t const payload[] = {0x81 ,0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length, true);
 
     REQUIRE(sync_callback_called == true);
@@ -146,10 +135,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
 
 /**************************************************************************************/
 
-SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback apply the AUTO_SYNC policy (the most recent value between the local one and the cloud one is finally assigned to the property). The onUpdate function is called if the cloud value is the most recent one. In this scenario the most updated value is the local one.")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback apply the AUTO_SYNC policy (the most recent value between the local one and the cloud one is finally assigned to the property). The onUpdate function is called if the cloud value is the most recent one. In this scenario the most updated value is the local one.") {
+  GIVEN("CloudProtocol::V2") {
     test = true;
     sync_callback_called = false;
     change_callback_called = false;
@@ -162,8 +149,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
     thing.updateTimestampOnChangedProperties(1550138811);
 
     /* [{-3: 1550138810.00, 0: "test", 4: true}] = 81 A3 22 FB 41 D7 19 4F 6E 80 00 00 00 64 74 65 73 74 04 F5 */
-    uint8_t const payload[] = {0x81 ,0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length, true);
 
     REQUIRE(sync_callback_called == true);
@@ -175,16 +162,13 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
 
 /**************************************************************************************/
 
-void force_device_sync_callback(ArduinoCloudProperty<bool> property)
-{
+void force_device_sync_callback(ArduinoCloudProperty<bool> property) {
   DEVICE_WINS(property);
   sync_callback_called = true;
 }
 
-SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the FORCE_DEVICE_SYNC policy (the property keeps the local value and, if the cloud value is different from the local one, the value is propagated to the cloud). The onUpdate function is not executed")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the FORCE_DEVICE_SYNC policy (the property keeps the local value and, if the cloud value is different from the local one, the value is propagated to the cloud). The onUpdate function is not executed") {
+  GIVEN("CloudProtocol::V2") {
 
     test = false;
     sync_callback_called = false;
@@ -196,8 +180,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).onUpdate(change_callback).onSync(force_device_sync_callback);
 
     /* [{-3: 1550138810.00, 0: "test", 4: true}] = 81 A3 22 FB 41 D7 19 4F 6E 80 00 00 00 64 74 65 73 74 04 F5 */
-    uint8_t const payload[] = {0x81 ,0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length, true);
 
     REQUIRE(sync_callback_called == true);
@@ -210,16 +194,13 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
 
 /**************************************************************************************/
 
-void force_cloud_sync_callback(ArduinoCloudProperty<bool> property)
-{
+void force_cloud_sync_callback(ArduinoCloudProperty<bool> property) {
   CLOUD_WINS(property);
   sync_callback_called = true;
 }
 
-SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the FORCE_CLOUD_SYNC policy (the property always assumes the value incoming from the broker message). The onUpdate function is executed only if the local value of the property was different from the one taken from the incoming message")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("After a connection/reconnection an incoming cbor payload is processed and the synchronization callback is executed. The sync callback applies the FORCE_CLOUD_SYNC policy (the property always assumes the value incoming from the broker message). The onUpdate function is executed only if the local value of the property was different from the one taken from the incoming message") {
+  GIVEN("CloudProtocol::V2") {
 
     test = false;
     sync_callback_called = false;
@@ -231,8 +212,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).onUpdate(change_callback).onSync(force_cloud_sync_callback);
 
     /* [{-3: 1550138810.00, 0: "test", 4: true}] = 81 A3 22 FB 41 D7 19 4F 6E 80 00 00 00 64 74 65 73 74 04 F5 */
-    uint8_t const payload[] = {0x81 ,0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length, true);
 
     REQUIRE(sync_callback_called == true);
@@ -244,10 +225,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed 
 
 /**************************************************************************************/
 
-SCENARIO("After a connection/reconnection an incoming cbor payload is processed. Any synchronization function is passed to the property so the value in the incoming message is discarded")
-{
-  GIVEN("CloudProtocol::V2")
-  {
+SCENARIO("After a connection/reconnection an incoming cbor payload is processed. Any synchronization function is passed to the property so the value in the incoming message is discarded") {
+  GIVEN("CloudProtocol::V2") {
 
     test = false;
     sync_callback_called = false;
@@ -259,8 +238,8 @@ SCENARIO("After a connection/reconnection an incoming cbor payload is processed.
     thing.addPropertyReal(test, "test", Permission::ReadWrite).onUpdate(change_callback);
 
     /* [{-3: 1550138810.00, 0: "test", 4: true}] = 81 A3 22 FB 41 D7 19 4F 6E 80 00 00 00 64 74 65 73 74 04 F5 */
-    uint8_t const payload[] = {0x81 ,0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x41, 0xD7, 0x19, 0x4F, 0x6E, 0x80, 0x00, 0x00, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5};
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length, true);
 
     REQUIRE(sync_callback_called == false);

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,17 +12,14 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
-{
+SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") {
   /************************************************************************************/
 
-  WHEN("A boolean property is changed via CBOR message")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A boolean property is changed via CBOR message") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -31,7 +28,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{0: "test", 4: false}] = 81 A2 00 64 74 65 73 74 04 F4 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF4};
-      int const payload_length = sizeof(payload)/sizeof(uint8_t);
+      int const payload_length = sizeof(payload) / sizeof(uint8_t);
       thing.decode(payload, payload_length);
 
       REQUIRE(test == false);
@@ -40,10 +37,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A int property is changed via CBOR message")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A int property is changed via CBOR message") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -52,13 +47,12 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{0: "test", 2: 7}] = 81 A2 00 64 74 65 73 74 02 07 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x07};
-      int const payload_length = sizeof(payload)/sizeof(uint8_t);
+      int const payload_length = sizeof(payload) / sizeof(uint8_t);
       thing.decode(payload, payload_length);
 
       REQUIRE(test == 7);
     }
-    GIVEN("CloudProtocol::V2")
-    {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -67,7 +61,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{0: "test", 2: -7}] = 81 A2 00 64 74 65 73 74 02 26 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x26};
-      int const payload_length = sizeof(payload)/sizeof(uint8_t);
+      int const payload_length = sizeof(payload) / sizeof(uint8_t);
       thing.decode(payload, payload_length);
 
       REQUIRE(test == -7);
@@ -76,10 +70,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A float property is changed via CBOR message")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A float property is changed via CBOR message") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -88,7 +80,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{0: "test", 2: 3.1459}] = 81 A2 00 64 74 65 73 74 02 FB 40 09 2A CD 9E 83 E4 26 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0xFB, 0x40, 0x09, 0x2A, 0xCD, 0x9E, 0x83, 0xE4, 0x26};
-      int const payload_length = sizeof(payload)/sizeof(uint8_t);
+      int const payload_length = sizeof(payload) / sizeof(uint8_t);
       thing.decode(payload, payload_length);
 
       REQUIRE(test == Approx(3.1459).epsilon(0.01));
@@ -97,10 +89,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A String property is changed via CBOR message")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A String property is changed via CBOR message") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -109,7 +99,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{0: "test", 3: "testtt"}] = 81 A2 00 64 74 65 73 74 03 66 74 65 73 74 74 74 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x03, 0x66, 0x74, 0x65, 0x73, 0x74, 0x74, 0x74};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(str == "testtt");
     }
@@ -117,12 +107,9 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("Multiple properties is changed via CBOR message")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
-      WHEN("Multiple properties of different type are changed via CBOR message")
-      {
+  WHEN("Multiple properties is changed via CBOR message") {
+    GIVEN("CloudProtocol::V2") {
+      WHEN("Multiple properties of different type are changed via CBOR message") {
         ArduinoCloudThing thing;
         thing.begin();
 
@@ -137,10 +124,10 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
         thing.addPropertyReal(str_test,   "str_test",   Permission::ReadWrite);
 
         /* [{0: "bool_test", 4: true}, {0: "int_test", 2: 10}, {0: "float_test", 2: 20.0}, {0: "str_test", 3: "hello arduino"}]
-         * = 84 A2 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F5 A2 00 68 69 6E 74 5F 74 65 73 74 02 0A A2 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 F9 4D 00 A2 00 68 73 74 72 5F 74 65 73 74 03 6D 68 65 6C 6C 6F 20 61 72 64 75 69 6E 6F
-         */
+           = 84 A2 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F5 A2 00 68 69 6E 74 5F 74 65 73 74 02 0A A2 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 F9 4D 00 A2 00 68 73 74 72 5F 74 65 73 74 03 6D 68 65 6C 6C 6F 20 61 72 64 75 69 6E 6F
+        */
         uint8_t const payload[] = {0x84, 0xA2, 0x00, 0x69, 0x62, 0x6F, 0x6F, 0x6C, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5, 0xA2, 0x00, 0x68, 0x69, 0x6E, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0x0A, 0xA2, 0x00, 0x6A, 0x66, 0x6C, 0x6F, 0x61, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0xF9, 0x4D, 0x00, 0xA2, 0x00, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6D, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x61, 0x72, 0x64, 0x75, 0x69, 0x6E, 0x6F};
-        thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+        thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
         REQUIRE(bool_test  == true);
         REQUIRE(int_test   == 10);
@@ -150,8 +137,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /********************************************************************************/
 
-      WHEN("Multiple properties of different type are synchronized via CBOR message. FORCE_CLOUD_SYNC is passed as synchronization function and as a consequence values contained in the incoming message are stored in the properties")
-      {
+      WHEN("Multiple properties of different type are synchronized via CBOR message. FORCE_CLOUD_SYNC is passed as synchronization function and as a consequence values contained in the incoming message are stored in the properties") {
         ArduinoCloudThing thing;
         thing.begin();
 
@@ -166,10 +152,10 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
         thing.addPropertyReal(str_test,   "str_test",   Permission::ReadWrite).onSync(CLOUD_WINS);
 
         /* [{0: "bool_test", 4: true}, {0: "int_test", 2: 10}, {0: "float_test", 2: 20.0}, {0: "str_test", 3: "hello arduino"}]
-         * = 84 A2 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F5 A2 00 68 69 6E 74 5F 74 65 73 74 02 0A A2 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 F9 4D 00 A2 00 68 73 74 72 5F 74 65 73 74 03 6D 68 65 6C 6C 6F 20 61 72 64 75 69 6E 6F
-         */
+           = 84 A2 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F5 A2 00 68 69 6E 74 5F 74 65 73 74 02 0A A2 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 F9 4D 00 A2 00 68 73 74 72 5F 74 65 73 74 03 6D 68 65 6C 6C 6F 20 61 72 64 75 69 6E 6F
+        */
         uint8_t const payload[] = {0x84, 0xA2, 0x00, 0x69, 0x62, 0x6F, 0x6F, 0x6C, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF5, 0xA2, 0x00, 0x68, 0x69, 0x6E, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0x0A, 0xA2, 0x00, 0x6A, 0x66, 0x6C, 0x6F, 0x61, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0xF9, 0x4D, 0x00, 0xA2, 0x00, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x03, 0x6D, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x61, 0x72, 0x64, 0x75, 0x69, 0x6E, 0x6F};
-        thing.decode(payload, sizeof(payload)/sizeof(uint8_t), true);
+        thing.decode(payload, sizeof(payload) / sizeof(uint8_t), true);
 
         REQUIRE(bool_test  == true);
         REQUIRE(int_test   == 10);
@@ -179,8 +165,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /********************************************************************************/
 
-      WHEN("Multiple String properties are changed via CBOR message")
-      {
+      WHEN("Multiple String properties are changed via CBOR message") {
         ArduinoCloudThing thing;
         thing.begin();
 
@@ -195,10 +180,10 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
         thing.addPropertyReal(str_4, "str_4", Permission::ReadWrite);
 
         /* [{0: "str_1", 3: "I'd like"}, {0: "str_2", 3: "a"}, {0: "str_3", 3: "cup"}, {0: "str_4", 3: "of coffee"}]
-         * = 84 A2 00 65 73 74 72 5F 31 03 68 49 27 64 20 6C 69 6B 65 A2 00 65 73 74 72 5F 32 03 61 61 A2 00 65 73 74 72 5F 33 03 63 63 75 70 A2 00 65 73 74 72 5F 34 03 69 6F 66 20 63 6F 66 66 65 65
-         */
+           = 84 A2 00 65 73 74 72 5F 31 03 68 49 27 64 20 6C 69 6B 65 A2 00 65 73 74 72 5F 32 03 61 61 A2 00 65 73 74 72 5F 33 03 63 63 75 70 A2 00 65 73 74 72 5F 34 03 69 6F 66 20 63 6F 66 66 65 65
+        */
         uint8_t const payload[] = {0x84, 0xA2, 0x00, 0x65, 0x73, 0x74, 0x72, 0x5F, 0x31, 0x03, 0x68, 0x49, 0x27, 0x64, 0x20, 0x6C, 0x69, 0x6B, 0x65, 0xA2, 0x00, 0x65, 0x73, 0x74, 0x72, 0x5F, 0x32, 0x03, 0x61, 0x61, 0xA2, 0x00, 0x65, 0x73, 0x74, 0x72, 0x5F, 0x33, 0x03, 0x63, 0x63, 0x75, 0x70, 0xA2, 0x00, 0x65, 0x73, 0x74, 0x72, 0x5F, 0x34, 0x03, 0x69, 0x6F, 0x66, 0x20, 0x63, 0x6F, 0x66, 0x66, 0x65, 0x65};
-        thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+        thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
         REQUIRE(str_1 == "I'd like");
         REQUIRE(str_2 == "a");
@@ -210,10 +195,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a CBOR base name is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a CBOR base name is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -222,7 +205,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{-2: "some-test-base-name", 0: "test", 3: "test"}] = 81 A3 21 73 73 6F 6D 65 2D 74 65 73 74 2D 62 61 73 65 2D 6E 61 6D 65 00 64 74 65 73 74 03 64 74 65 73 74 */
       uint8_t const payload[] = {0x81, 0xA3, 0x21, 0x73, 0x73, 0x6F, 0x6D, 0x65, 0x2D, 0x74, 0x65, 0x73, 0x74, 0x2D, 0x62, 0x61, 0x73, 0x65, 0x2D, 0x6E, 0x61, 0x6D, 0x65, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x03, 0x64, 0x74, 0x65, 0x73, 0x74};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(str == "test");
     }
@@ -230,10 +213,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a CBOR base time is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a CBOR base time is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -242,7 +223,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{-3: 123.456, 0: "test", 2: 1}] = 81 A3 22 FB 40 5E DD 2F 1A 9F BE 77 00 64 74 65 73 74 02 01 */
       uint8_t const payload[] = {0x81, 0xA3, 0x22, 0xFB, 0x40, 0x5E, 0xDD, 0x2F, 0x1A, 0x9F, 0xBE, 0x77, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(test == 1);
     }
@@ -250,10 +231,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a CBOR time is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a CBOR time is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -262,7 +241,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{6: 123.456, 0: "test", 2: 1}] = 81 A3 06 FB 40 5E DD 2F 1A 9F BE 77 00 64 74 65 73 74 02 01 */
       uint8_t const payload[] = {0x81, 0xA3, 0x06, 0xFB, 0x40, 0x5E, 0xDD, 0x2F, 0x1A, 0x9F, 0xBE, 0x77, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(test == 1);
     }
@@ -270,10 +249,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a CBOR BaseVersion is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a CBOR BaseVersion is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -282,7 +259,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{-1: 1, 0: "test", 2: 1}] = 81 A3 20 01 00 64 74 65 73 74 02 01 */
       uint8_t const payload[] = {0x81, 0xA3, 0x20, 0x01, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(test == 1);
     }
@@ -290,10 +267,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a CBOR BaseName, BaseTime and Time is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a CBOR BaseName, BaseTime and Time is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -301,10 +276,10 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
       thing.addPropertyReal(test, "test", Permission::ReadWrite);
 
       /* [{-2: "base-name", -3: 654.321, 6: 123.456, 0: "test", 2: 1}] =
-       * 81 A5 21 69 62 61 73 65 2D 6E 61 6D 65 22 FB 40 84 72 91 68 72 B0 21 06 FB 40 5E DD 2F 1A 9F BE 77 00 64 74 65 73 74 02 01
-       */
+         81 A5 21 69 62 61 73 65 2D 6E 61 6D 65 22 FB 40 84 72 91 68 72 B0 21 06 FB 40 5E DD 2F 1A 9F BE 77 00 64 74 65 73 74 02 01
+      */
       uint8_t const payload[] = {0x81, 0xA5, 0x21, 0x69, 0x62, 0x61, 0x73, 0x65, 0x2D, 0x6E, 0x61, 0x6D, 0x65, 0x22, 0xFB, 0x40, 0x84, 0x72, 0x91, 0x68, 0x72, 0xB0, 0x21, 0x06, 0xFB, 0x40, 0x5E, 0xDD, 0x2F, 0x1A, 0x9F, 0xBE, 0x77, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(test == 1);
     }
@@ -312,10 +287,8 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
   /************************************************************************************/
 
-  WHEN("A payload containing a invalid CBOR key is parsed")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A payload containing a invalid CBOR key is parsed") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -324,7 +297,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]")
 
       /* [{123: 123, 0: "test", 2: 1}] = 81 A3 18 7B 18 7B 00 64 74 65 73 74 02 01 */
       uint8_t const payload[] = {0x81, 0xA3, 0x18, 0x7B, 0x18, 0x7B, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01};
-      thing.decode(payload, sizeof(payload)/sizeof(uint8_t));
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       REQUIRE(test == 1);
     }

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,17 +12,14 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
-{
+SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") {
   /************************************************************************************/
 
-  WHEN("A 'bool' property is added")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A 'bool' property is added") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
@@ -39,10 +36,8 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   /************************************************************************************/
 
-  WHEN("A 'int' property is added")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A 'int' property is added") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
@@ -59,10 +54,8 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   /************************************************************************************/
 
-  WHEN("A 'float' property is added")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A 'float' property is added") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
@@ -79,10 +72,8 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   /************************************************************************************/
 
-  WHEN("A 'String' property is added")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("A 'String' property is added") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
@@ -99,10 +90,8 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
 
   /************************************************************************************/
 
-  WHEN("Multiple properties are added")
-  {
-    GIVEN("CloudProtocol::V2")
-    {
+  WHEN("Multiple properties are added") {
+    GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
@@ -117,8 +106,8 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]")
       thing.addPropertyReal(str_test,   "str_test",   Permission::ReadWrite);
 
       /* [{0: "bool_test", 4: false}, {0: "int_test", 2: 1}, {0: "float_test", 2: 2.0}, {0: "str_test", 3: "str_test"}]
-       * = 84 BF 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F4 FF BF 00 68 69 6E 74 5F 74 65 73 74 02 01 FF BF 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 FA 40 00 00 00 FF BF 00 68 73 74 72 5F 74 65 73 74 03 68 73 74 72 5F 74 65 73 74 FF
-       */
+         = 84 BF 00 69 62 6F 6F 6C 5F 74 65 73 74 04 F4 FF BF 00 68 69 6E 74 5F 74 65 73 74 02 01 FF BF 00 6A 66 6C 6F 61 74 5F 74 65 73 74 02 FA 40 00 00 00 FF BF 00 68 73 74 72 5F 74 65 73 74 03 68 73 74 72 5F 74 65 73 74 FF
+      */
       std::vector<uint8_t> const expected = {0x84, 0xBF, 0x00, 0x69, 0x62, 0x6F, 0x6F, 0x6C, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x04, 0xF4, 0xFF, 0xBF, 0x00, 0x68, 0x69, 0x6E, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0x01, 0xFF, 0xBF, 0x00, 0x6A, 0x66, 0x6C, 0x6F, 0x61, 0x74, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xFF, 0xBF, 0x00, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0x03, 0x68, 0x73, 0x74, 0x72, 0x5F, 0x74, 0x65, 0x73, 0x74, 0xFF};
       std::vector<uint8_t> const actual = encode(thing);
       REQUIRE(actual == expected);

--- a/test/src/test_publishEvery.cpp
+++ b/test/src/test_publishEvery.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,15 +12,13 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThing::publishEvery]")
-{
+SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThing::publishEvery]") {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V2")
-  {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -29,39 +27,29 @@ SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThi
 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).publishEvery(PUBLISH_INTERVAL_SEC);
 
-    WHEN("t = 0 ms, publish interval = 1000 ms, 1st call to 'encode'")
-    {
+    WHEN("t = 0 ms, publish interval = 1000 ms, 1st call to 'encode'") {
       set_millis(0);
-      THEN("'encode' should encode the property")
-      {
+      THEN("'encode' should encode the property") {
         REQUIRE(encode(thing).size() != 0);
-        WHEN("t = 999 ms")
-        {
+        WHEN("t = 999 ms") {
           set_millis(999);
-          THEN("'encode' should not encode the property")
-          {
+          THEN("'encode' should not encode the property") {
             REQUIRE(encode(thing).size() == 0);
-            WHEN("t = 1000 ms")
-            {
+            WHEN("t = 1000 ms") {
               set_millis(1000);
-              THEN("'encode' should encode the property")
-              {
+              THEN("'encode' should encode the property") {
                 REQUIRE(encode(thing).size() != 0);
-                WHEN("t = 1999 ms")
-                {
-                 set_millis(1999);
-                 THEN("'encode' should not encode the property")
-                 {
-                   REQUIRE(encode(thing).size() == 0);
-                   WHEN("t = 2000 ms")
-                   {
-                     set_millis(2000);
-                     THEN("'encode' should encode the property")
-                     {
-                       REQUIRE(encode(thing).size() != 0);
-                     }
-                   }
-                 }
+                WHEN("t = 1999 ms") {
+                  set_millis(1999);
+                  THEN("'encode' should not encode the property") {
+                    REQUIRE(encode(thing).size() == 0);
+                    WHEN("t = 2000 ms") {
+                      set_millis(2000);
+                      THEN("'encode' should encode the property") {
+                        REQUIRE(encode(thing).size() != 0);
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/test/src/test_publishOnChange.cpp
+++ b/test/src/test_publishOnChange.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,15 +12,13 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A Arduino cloud property is published on value change", "[ArduinoCloudThing::publishOnChange]")
-{
+SCENARIO("A Arduino cloud property is published on value change", "[ArduinoCloudThing::publishOnChange]") {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V2")
-  {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -29,23 +27,17 @@ SCENARIO("A Arduino cloud property is published on value change", "[ArduinoCloud
 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).publishOnChange(DELTA);
 
-    WHEN("test = 10, delta = 6, the property is encoded for the 1st time")
-    {
-      THEN("The property should be encoded")
-      {
+    WHEN("test = 10, delta = 6, the property is encoded for the 1st time") {
+      THEN("The property should be encoded") {
         REQUIRE(encode(thing).size() != 0);
-        WHEN("test +=4 -> test = 14")
-        {
-          test +=4;
-          THEN("Since the increment since the last update (4) is smaller than the delta of 6 the property should not be encoded")
-          {
+        WHEN("test +=4 -> test = 14") {
+          test += 4;
+          THEN("Since the increment since the last update (4) is smaller than the delta of 6 the property should not be encoded") {
             REQUIRE(encode(thing).size() == 0);
-            WHEN("test +=4 -> test = 18")
-            {
-              test +=4;
-              THEN("Since the increment since the last update (8) is greater than the delta of 6 the property should be encoded")
-              {
-              REQUIRE(encode(thing).size() != 0);
+            WHEN("test +=4 -> test = 18") {
+              test += 4;
+              THEN("Since the increment since the last update (8) is greater than the delta of 6 the property should be encoded") {
+                REQUIRE(encode(thing).size() != 0);
               }
             }
           }

--- a/test/src/test_publishOnChangeRateLimit.cpp
+++ b/test/src/test_publishOnChangeRateLimit.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,15 +12,13 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A Arduino cloud property is published on value change but the update rate is limited", "[ArduinoCloudThing::publishOnChange]")
-{
+SCENARIO("A Arduino cloud property is published on value change but the update rate is limited", "[ArduinoCloudThing::publishOnChange]") {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V2")
-  {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -30,39 +28,29 @@ SCENARIO("A Arduino cloud property is published on value change but the update r
 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).publishOnChange(MIN_DELTA, MIN_TIME_BETWEEN_UPDATES_ms);
 
-    WHEN("t = 0 ms, min time between updates = 500 ms, property not modified, 1st call to 'encode'")
-    {
+    WHEN("t = 0 ms, min time between updates = 500 ms, property not modified, 1st call to 'encode'") {
       set_millis(0);
-      THEN("'encode' should encode the property")
-      {
+      THEN("'encode' should encode the property") {
         REQUIRE(encode(thing).size() != 0);
-        WHEN("t = 499 ms, property modified")
-        {
+        WHEN("t = 499 ms, property modified") {
           test++;
           set_millis(499);
-          THEN("'encode' should not encode any property")
-          {
+          THEN("'encode' should not encode any property") {
             REQUIRE(encode(thing).size() == 0);
-            WHEN("t = 500 ms, property modified")
-            {
+            WHEN("t = 500 ms, property modified") {
               test++;
               set_millis(500);
-              THEN("'encode' should encode the property")
-              {
+              THEN("'encode' should encode the property") {
                 REQUIRE(encode(thing).size() != 0);
-                WHEN("t = 999 ms, property modified")
-                {
+                WHEN("t = 999 ms, property modified") {
                   test++;
                   set_millis(999);
-                  THEN("'encode' should not encode any property")
-                  {
+                  THEN("'encode' should not encode any property") {
                     REQUIRE(encode(thing).size() == 0);
-                    WHEN("t = 1000 ms, property modified")
-                    {
+                    WHEN("t = 1000 ms, property modified") {
                       test++;
                       set_millis(1000);
-                      THEN("'encode' should encode the property")
-                      {
+                      THEN("'encode' should encode the property") {
                         REQUIRE(encode(thing).size() != 0);
                       }
                     }

--- a/test/src/test_readOnly.cpp
+++ b/test/src/test_readOnly.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,15 +12,13 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A Arduino cloud property is marked 'read only'", "[ArduinoCloudThing::decode]")
-{
+SCENARIO("A Arduino cloud property is marked 'read only'", "[ArduinoCloudThing::decode]") {
   /************************************************************************************/
 
-  GIVEN("CloudProtocol::V2")
-  {
+  GIVEN("CloudProtocol::V2") {
     ArduinoCloudThing thing;
     thing.begin();
 
@@ -29,7 +27,7 @@ SCENARIO("A Arduino cloud property is marked 'read only'", "[ArduinoCloudThing::
 
     /* [{0: "test", 2: 7}] = 81 A2 00 64 74 65 73 74 02 07 */
     uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x64, 0x74, 0x65, 0x73, 0x74, 0x02, 0x07};
-    int const payload_length = sizeof(payload)/sizeof(uint8_t);
+    int const payload_length = sizeof(payload) / sizeof(uint8_t);
     thing.decode(payload, payload_length);
 
     REQUIRE(test == 0);

--- a/test/src/test_writeOnly.cpp
+++ b/test/src/test_writeOnly.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2019 Arduino.  All rights reserved.
- */
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
 
 /**************************************************************************************
- * INCLUDE
+   INCLUDE
  **************************************************************************************/
 
 #include <catch.hpp>
@@ -12,11 +12,10 @@
 #include <ArduinoCloudThing.h>
 
 /**************************************************************************************
- * TEST CODE
+   TEST CODE
  **************************************************************************************/
 
-SCENARIO("A Arduino cloud property is marked 'write only'", "[ArduinoCloudThing::encode]")
-{
+SCENARIO("A Arduino cloud property is marked 'write only'", "[ArduinoCloudThing::encode]") {
   /************************************************************************************/
 
   ArduinoCloudThing thing;


### PR DESCRIPTION
- Auto format code
- Add code formatting check to Travis CI build
- Use TravisBuddy to comment on PRs that result in a failed CI build

Check compliance with the Artistic Style code formatter configuration found in https://github.com/arduino/Arduino/blob/master/build/shared/examples_formatter.conf. A consistent style will be used for example sketches as well as library code.

This required first doing an auto format of all the code in the repository.

I excluded the `./src/lib` and `./test/external` folders from the auto formatting and the formatting check because these appeared to contain only external projects. I felt that it didn't make sense to enforce a formatting standard on these projects, since that would likely make it more difficult to update these files and to view changes between updates. If you do want me to enable formatting checks on any of these folders, let me know, I'm happy to update this PR accordingly.

A TravisBuddy webhook was added to the Travis CI build configuration. TravisBuddy will automatically comment on any pull request that results in a failing Travis CI build so that the author of the PR will get a notification of the issue and hopefully resolve it without the need for any action from a repository maintainer.

Example of a build failure caused by non-compliant code formatting:
https://travis-ci.org/per1234/ArduinoCloudThing/jobs/517619571

Example of TravisBuddy automated comment on a demonstration pull request that failed the code formatting check:
https://github.com/per1234/ArduinoCloudThing/pull/1
![Clipboard02](https://user-images.githubusercontent.com/8572152/55775896-b2c9da00-5a4f-11e9-90d7-5a1992bf7ef5.png)


Related:
- https://github.com/arduino/ArduinoCore-avr/issues/71
- https://github.com/arduino/Arduino/issues/6503