### PR TITLE
Check for commonly misspelled words during the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,18 @@ matrix:
         # check code formatting
         - find . -regextype posix-extended -path './.git' -prune -or -path './src/lib' -prune -or -path './test/external' -prune -or \( -iregex '.*\.((ino)|(h)|(hpp)|(hh)|(hxx)|(h\+\+)|(cpp)|(cc)|(cxx)|(c\+\+)|(cp)|(c)|(ipp)|(ii)|(ixx)|(inl)|(tpp)|(txx)|(tpl))$' -and -type f \) -print0 | xargs -0 -L1 bash -c 'if ! diff $0 <(astyle --options=${HOME}/astyle/examples_formatter.conf --dry-run < $0); then echo "Non-compliant code formatting in $0"; false; fi'
 
+    - env:
+      - NAME=Spell Check
+
+      language: python
+      python: 3.6
+
+      install:
+        # https://github.com/codespell-project/codespell
+        - pip install codespell
+      script:
+        - codespell --skip="${TRAVIS_BUILD_DIR}/.git","${TRAVIS_BUILD_DIR}/src/lib","${TRAVIS_BUILD_DIR}/test/external" --ignore-words="${TRAVIS_BUILD_DIR}/extras/codespell-ignore-words-list.txt" "${TRAVIS_BUILD_DIR}"
+
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
If any word is found that is on a list of commonly misspelled words, the Travis CI build will fail and a correction will be suggested in the build log.

[codespell](https://github.com/codespell-project/codespell) is a blacklist-based spell checker. This approach is more appropriate for a CI build because it results in far less false positives than would traditional whitelist-based spell checking, with the disadvantage of having more false negatives. So it won't catch all the typos, but it also won't be spuriously breaking every other build.

When false positives do occur, they can be resolved by adding the problematic word to extras/codespell-ignore-words-list.txt

I configured codespell to ignore the contents of src/lib and test/external because these appear to contain external projects and spell checking of those files would be better done in their own repositories.

Example of a build that failed from a misspelled word being detected:
https://travis-ci.org/per1234/ArduinoCloudThing/builds/519203026