### PR TITLE
Set CI build warning level to -Wall -Wextra -Wpedantic -Werror and fix all warnings

### DIFF
--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -26,7 +26,7 @@ static unsigned long getTimestamp() {
   #ifdef ARDUINO_ARCH_SAMD
   return rtc.getEpoch();
   #else
-#warning "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
+#pragma message "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
   return 0;
   #endif
 }
@@ -35,19 +35,19 @@ static unsigned long getTimestamp() {
    CTOR/DTOR
  ******************************************************************************/
 ArduinoCloudProperty::ArduinoCloudProperty()
-  : _name(""),
-    _permission(Permission::Read),
-    _update_callback_func(nullptr),
-    _sync_callback_func(nullptr),
-    _has_been_updated_once(false),
-    _has_been_modified_in_callback(false),
-    _min_delta_property(0.0f),
-    _min_time_between_updates_millis(0),
-    _last_updated_millis(0),
-    _update_interval_millis(0),
-    _last_local_change_timestamp(0),
-    _last_cloud_change_timestamp(0),
-    _map_data_list(nullptr) {
+  :   _name(""),
+      _min_delta_property(0.0f),
+      _min_time_between_updates_millis(0),
+      _permission(Permission::Read),
+      _update_callback_func(nullptr),
+      _sync_callback_func(nullptr),
+      _has_been_updated_once(false),
+      _has_been_modified_in_callback(false),
+      _last_updated_millis(0),
+      _update_interval_millis(0),
+      _last_local_change_timestamp(0),
+      _last_cloud_change_timestamp(0),
+      _map_data_list(nullptr) {
 }
 
 /******************************************************************************

--- a/src/ArduinoCloudProperty.h
+++ b/src/ArduinoCloudProperty.h
@@ -178,9 +178,9 @@ class ArduinoCloudProperty {
     };
   protected:
     /* Variables used for UpdatePolicy::OnChange */
+    String             _name;
     float              _min_delta_property;
     unsigned long      _min_time_between_updates_millis;
-    String             _name;
 
   private:
     Permission         _permission;

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -47,8 +47,8 @@ ArduinoCloudThing::ArduinoCloudThing() :
   _numPrimitivesProperties(0),
   _isSyncMessage(false),
   _currentPropertyName(""),
-  _currentPropertyTime(0),
-  _currentPropertyBaseTime(0)
+  _currentPropertyBaseTime(0),
+  _currentPropertyTime(0)
 {}
 
 /******************************************************************************
@@ -515,5 +515,5 @@ void onForceCloudSync(ArduinoCloudProperty & property) {
   property.execCallbackOnChange();
 }
 
-void onForceDeviceSync(ArduinoCloudProperty & property) {
+void onForceDeviceSync(ArduinoCloudProperty & /* property */) {
 }

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -36,8 +36,8 @@
    CONSTANTS
  ******************************************************************************/
 
-static bool ON  = true;
-static bool OFF = false;
+static bool const ON  = true;
+static bool const OFF = false;
 
 static long const ON_CHANGE = -1;
 static long const SECONDS   = 1;

--- a/src/lib/tinycbor/src/cborencoder.c
+++ b/src/lib/tinycbor/src/cborencoder.c
@@ -39,6 +39,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \defgroup CborEncoding Encoding to CBOR
  * \brief Group of functions used to encode data to CBOR.
@@ -641,5 +644,7 @@ CborError cbor_encoder_close_container(CborEncoder *encoder, const CborEncoder *
  *
  * \sa cbor_encoder_init(), cbor_encoder_get_buffer_size(), CborEncoding
  */
+
+#pragma GCC diagnostic pop
 
 /** @} */

--- a/src/lib/tinycbor/src/cborencoder_close_container_checked.c
+++ b/src/lib/tinycbor/src/cborencoder_close_container_checked.c
@@ -30,6 +30,9 @@
 
 #include "cbor.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \addtogroup CborEncoding
  * @{
@@ -53,5 +56,7 @@ CborError cbor_encoder_close_container_checked(CborEncoder *encoder, const CborE
 {
     return cbor_encoder_close_container(encoder, containerEncoder);
 }
+
+#pragma GCC diagnostic pop
 
 /** @} */

--- a/src/lib/tinycbor/src/cborerrorstrings.c
+++ b/src/lib/tinycbor/src/cborerrorstrings.c
@@ -28,6 +28,9 @@
 #  define _(msg)    msg
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \enum CborError
  * \ingroup CborGlobals
@@ -180,3 +183,5 @@ const char *cbor_error_string(CborError error)
     }
     return cbor_error_string(CborUnknownError);
 }
+
+#pragma GCC diagnostic pop

--- a/src/lib/tinycbor/src/cborparser.c
+++ b/src/lib/tinycbor/src/cborparser.c
@@ -38,6 +38,9 @@
 
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \defgroup CborParsing Parsing CBOR streams
  * \brief Group of functions used to parse CBOR streams.
@@ -1426,5 +1429,7 @@ CborError cbor_value_get_half_float(const CborValue *value, void *result)
     memcpy(result, &v, sizeof(v));
     return CborNoError;
 }
+
+#pragma GCC diagnostic pop
 
 /** @} */

--- a/src/lib/tinycbor/src/cborparser_dup_string.c
+++ b/src/lib/tinycbor/src/cborparser_dup_string.c
@@ -36,6 +36,9 @@
 #include "compilersupport_p.h"
 #include <stdlib.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \fn CborError cbor_value_dup_text_string(const CborValue *value, char **buffer, size_t *buflen, CborValue *next)
  *
@@ -117,3 +120,5 @@ CborError _cbor_value_dup_string(const CborValue *value, void **buffer, size_t *
     }
     return CborNoError;
 }
+
+#pragma GCC diagnostic pop

--- a/src/lib/tinycbor/src/cborpretty.c
+++ b/src/lib/tinycbor/src/cborpretty.c
@@ -36,6 +36,9 @@
 #include <inttypes.h>
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \defgroup CborPretty Converting CBOR to text
  * \brief Group of functions used to convert CBOR to text form.
@@ -574,5 +577,7 @@ CborError cbor_value_to_pretty_stream(CborStreamFunction streamFunction, void *t
 {
     return value_to_pretty(streamFunction, token, value, flags, CBOR_PARSER_MAX_RECURSIONS);
 }
+
+#pragma GCC diagnostic pop
 
 /** @} */

--- a/src/lib/tinycbor/src/cborpretty_stdio.c
+++ b/src/lib/tinycbor/src/cborpretty_stdio.c
@@ -26,6 +26,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 static CborError cbor_fprintf(void *out, const char *fmt, ...)
 {
     int n;
@@ -85,3 +88,4 @@ CborError cbor_value_to_pretty_advance_flags(FILE *out, CborValue *value, int fl
     return cbor_value_to_pretty_stream(cbor_fprintf, out, value, flags);
 }
 
+#pragma GCC diagnostic pop

--- a/src/lib/tinycbor/src/cbortojson.c
+++ b/src/lib/tinycbor/src/cbortojson.c
@@ -40,6 +40,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \defgroup CborToJson Converting CBOR to JSON
  * \brief Group of functions used to convert CBOR to JSON.
@@ -695,5 +698,7 @@ CborError cbor_value_to_json_advance(FILE *out, CborValue *value, int flags)
     ConversionStatus status;
     return value_to_json(out, value, flags, cbor_value_get_type(value), &status);
 }
+
+#pragma GCC diagnostic pop
 
 /** @} */

--- a/src/lib/tinycbor/src/cborvalidation.c
+++ b/src/lib/tinycbor/src/cborvalidation.c
@@ -45,6 +45,9 @@
 #  define CBOR_PARSER_MAX_RECURSIONS 1024
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 /**
  * \addtogroup CborParsing
  * @{
@@ -660,6 +663,8 @@ CborError cbor_value_validate(const CborValue *it, uint32_t flags)
         return CborErrorGarbageAtEnd;
     return CborNoError;
 }
+
+#pragma GCC diagnostic pop
 
 /**
  * @}

--- a/src/lib/tinycbor/src/open_memstream.c
+++ b/src/lib/tinycbor/src/open_memstream.c
@@ -39,6 +39,9 @@ typedef size_t LenType;
 
 #include "compilersupport_p.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 struct Buffer
 {
     char **ptr;
@@ -57,8 +60,8 @@ static RetType write_to_buffer(void *cookie, const char *data, LenType len)
         return -1;
 
     if (newsize > b->alloc) {
-        // make room
-        size_t newalloc = newsize + newsize / 2 + 1;    // give 50% more room
+        /* make room */
+        size_t newalloc = newsize + newsize / 2 + 1;    /* give 50% more room */
         ptr = realloc(ptr, newalloc);
         if (ptr == NULL)
             return -1;
@@ -104,3 +107,4 @@ FILE *open_memstream(char **bufptr, size_t *lenptr)
 #endif
 }
 
+#pragma GCC diagnostic pop

--- a/src/types/CloudColor.h
+++ b/src/types/CloudColor.h
@@ -52,19 +52,15 @@ class Color {
     }
 
     bool setColorRGB(uint8_t R, uint8_t G, uint8_t B) {
-      if (R < 0 || R > 255 || G < 0 || G > 255 || B < 0 || B > 255) {
-        return false;
-      }
       float temp[3];
       float max, min, delta;
-      uint8_t imax, imin;
+      uint8_t imax;
       temp[0] = (float)R / 255;
       temp[1] = (float)G / 255;
       temp[2] = (float)B / 255;
       max = temp[0];
       imax = 0;
       min = temp[0];
-      imin = 0;
 
       for (uint8_t j = 0; j < 3; j++) {
 
@@ -74,7 +70,6 @@ class Color {
         }
         if (temp[j] <= min) {
           min = temp[j];
-          imin = j;
         }
       }
 

--- a/src/types/CloudFloat.h
+++ b/src/types/CloudFloat.h
@@ -88,12 +88,10 @@ class CloudFloat : public ArduinoCloudProperty {
       return operator=(_value - 1.0f);
     }
     CloudFloat operator++(int) {
-      float f = _value;
       operator=(_value + 1.0f);
       return CloudFloat(_value);
     }
     CloudFloat operator--(int) {
-      float f = _value;
       operator=(_value - 1.0f);
       return CloudFloat(_value);
     }

--- a/src/types/CloudInt.h
+++ b/src/types/CloudInt.h
@@ -89,12 +89,10 @@ class CloudInt : public ArduinoCloudProperty {
       return operator=(--_value);
     }
     CloudInt operator++(int) {
-      int temp = _value;
       operator=(_value + 1);
       return CloudInt(_value);
     }
     CloudInt operator--(int) {
-      int temp = _value;
       operator=(_value - 1);
       return CloudInt(_value);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_SRCS
 ##########################################################################
 
 add_definitions(-DHOST_BUILD)
+add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
 set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")

--- a/test/src/test_CloudColor.cpp
+++ b/test/src/test_CloudColor.cpp
@@ -32,7 +32,6 @@ SCENARIO("Arduino Cloud Properties ", "[ArduinoCloudThing::CloudColor]") {
   WHEN("Set and Get different RGB colors") {
     GIVEN("CloudProtocol::V2") {
 
-      bool verify;
       uint8_t r, g, b;
 
       CloudColor color_test = CloudColor(0.0, 0.0, 0.0);


### PR DESCRIPTION
EDIT: This PR ended up going beyond my original intent of enabling warnings to fixing all the warnings, thanks to the work of @lxrobotics!

Compiler warnings will be displayed in the Travis CI build log and the build will fail if any warnings are encountered.

The Travis CI build for this PR is expected to fail due to warnings caused by the ArduinoCloudThing code.

Related: https://github.com/arduino-libraries/ArduinoIoTCloud/issues/67