### PR TITLE
Fix false positive in the Spell Check CI job

### DIFF
--- a/extras/codespell-ignore-words-list.txt
+++ b/extras/codespell-ignore-words-list.txt
@@ -1,0 +1,1 @@
+alocation


### PR DESCRIPTION
A new version of codespell was released with an updated list of commonly misspelled words. This resulted in a false positive on "aLocation". I added that word to the ignore list to fix the false positive.