### PR TITLE
Presetting variable next_state with defined value

### DIFF
--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -123,7 +123,7 @@ void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const lengt
   _currentPropertyName = "";
 
   MapParserState current_state = MapParserState::EnterMap,
-                 next_state;
+                 next_state = MapParserState::Error;
 
   while (current_state != MapParserState::Complete) {
 


### PR DESCRIPTION
This PR is necessary because this issue was uncovered when compiling `ArduinoIoTCloud` with stronger compile time checks ( https://github.com/arduino-libraries/ArduinoIoTCloud/pull/69 ).