### PR TITLE
 Correcting semantic usage of overloaded Location::operator -

### DIFF
--- a/src/types/CloudLocation.h
+++ b/src/types/CloudLocation.h
@@ -42,14 +42,17 @@ class Location {
       lon = aLocation.lon;
       return *this;
     }
-    float operator-(Location& aLocation) {
-      return sqrt(pow(lat - aLocation.lat, 2) + pow(lon - aLocation.lon, 2));
+    Location operator-(Location& aLocation) {
+      return Location(lat - aLocation.lat, lon - aLocation.lon);
     }
     bool operator==(Location& aLocation) {
       return lat == aLocation.lat && lon == aLocation.lon;
     }
     bool operator!=(Location& aLocation) {
       return !(operator==(aLocation));
+    }
+    static float distance(Location& loc1, Location& loc2) {
+      return sqrt(pow(loc1.lat - loc2.lat, 2) + pow(loc1.lon - loc2.lon, 2));
     }
 };
 
@@ -61,7 +64,7 @@ class CloudLocation : public ArduinoCloudProperty {
     CloudLocation() : _value(0, 0), _cloud_value(0, 0) {}
     CloudLocation(float lat, float lon) : _value(lat, lon), _cloud_value(lat, lon) {}
     virtual bool isDifferentFromCloud() {
-      float distance = _value - _cloud_value;
+      float const distance = Location::distance(_value, _cloud_value);
       return _value != _cloud_value && (abs(distance) >= ArduinoCloudProperty::_min_delta_property);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,8 @@ set(TEST_SRCS
   src/main.cpp
   src/test_addPropertyReal.cpp
   src/test_callback.cpp
+  src/test_CloudColor.cpp
+  src/test_CloudLocation.cpp
   src/test_decode.cpp
   src/test_encode.cpp
   src/test_publishEvery.cpp
@@ -32,7 +34,6 @@ set(TEST_SRCS
   src/test_readOnly.cpp
   src/test_writeOnly.cpp
   src/TestUtil.cpp
-  src/test_CloudColor.cpp
 
   ../src/ArduinoCloudThing.cpp
   ../src/ArduinoCloudProperty.cpp

--- a/test/src/test_CloudLocation.cpp
+++ b/test/src/test_CloudLocation.cpp
@@ -1,0 +1,102 @@
+/*
+   Copyright (c) 2019 Arduino.  All rights reserved.
+*/
+
+/**************************************************************************************
+   INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <ArduinoCloudThing.h>
+
+/**************************************************************************************
+  TEST CODE
+ **************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' Ctor", "[Location::Location]") {
+  WHEN("A Location(1.0f, 2.0f) is being instantiated") {
+    Location loc(1.0f, 2.0f);
+    THEN("The member variable 'lat' should be 1.0f") {
+      REQUIRE(loc.lat == 1.0f);
+    }
+    THEN("The member variable 'lon' should be 2.0f") {
+      REQUIRE(loc.lon == 2.0f);
+    }
+  }
+}
+
+/**************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' assignment operator", "[Location::operator =]") {
+  Location loc1(1.0f, 2.0f),
+           loc2(3.0f, 4.0f);
+  loc1 = loc2;
+  WHEN("One location is assigned to the other") {
+    THEN("The coordinates of the second location should be assigned to the first") {
+      REQUIRE(loc1.lat == 3.0f);
+      REQUIRE(loc1.lon == 4.0f);
+    }
+  }
+}
+
+/**************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' operator -", "[Location::operator -]") {
+  Location loc1(1.0f, 2.0f),
+           loc2(3.0f, 4.0f);
+  Location loc3 = loc1 - loc2;
+  WHEN("One location is subtracted from the other") {
+    THEN("The result should be calculated according the rule lon3 = lon1 - lon2, lat3 = lat1 - lat2") {
+      REQUIRE(loc3.lat == loc1.lat - loc2.lat);
+      REQUIRE(loc3.lon == loc1.lon - loc2.lon);
+    }
+  }
+}
+
+/**************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' comparison operator ==", "[Location::operator ==]") {
+  Location loc1(1.0f, 2.0f),
+           loc2(3.0f, 4.0f),
+           loc3(1.0f, 2.0f);
+  WHEN("Two locations are identical (lat as well as lon)") {
+    THEN("The comparison operation should return true") {
+      REQUIRE((loc1 == loc3) == true);
+    }
+  }
+
+  WHEN("Two locations are not identical (either lat or lon do not match)") {
+    THEN("The comparison operation should return false") {
+      REQUIRE((loc1 == loc2) == false);
+    }
+  }
+}
+
+/**************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' comparison operator !=", "[Location::operator !=]") {
+  Location loc1(1.0f, 2.0f),
+           loc2(3.0f, 4.0f),
+           loc3(1.0f, 2.0f);
+  WHEN("Two locations are identical (lat as well as lon)") {
+    THEN("The comparison operation should return false") {
+      REQUIRE((loc1 != loc3) == false);
+    }
+  }
+
+  WHEN("Two locations are not identical (either lat or lon do not match)") {
+    THEN("The comparison operation should return true") {
+      REQUIRE((loc1 != loc2) == true);
+    }
+  }
+}
+
+/**************************************************************************************/
+
+SCENARIO("Tesing cloud type 'Location' function distance for calculating euclidean 2d distance between two points", "[Location::distance]") {
+  Location loc1(0.0f, 0.0f),
+           loc2(1.0f, 1.0f);
+
+  REQUIRE(Location::distance(loc1, loc2) == sqrt(2.0f));
+}


### PR DESCRIPTION
This pull request consists of two parts:
- Correction of the semantic usage of the `Location::operator -` and introducation of a function `distance(...)` which fulfils the task of calculating the euclidean distance between 2 Locations.
- Adding of test code to verify correct functionality of class `Location`
