### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Easly connect your Arduino/Genuino board to the Arduino Cloud
 category=Communication
 url=https://github.com/arduino-libraries/ArduinoCloudThing
 architectures=*
+depends=RTCZero

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoCloudThing
-version=1.6.4
+version=1.6.5
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Easly connect your Arduino/Genuino board to the Arduino Cloud


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format