### PR TITLE
LoRa support

### DIFF
--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -23,7 +23,12 @@
 #endif
 
 static unsigned long getTimestamp() {
+  #ifdef ARDUINO_ARCH_SAMD
+  return rtc.getEpoch();
+  #else
+#pragma message "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
   return 0;
+  #endif
 }
 
 /******************************************************************************

--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -154,7 +154,9 @@ void ArduinoCloudProperty::appendAttributeName(String attributeName, std::functi
 
   #ifdef SerialLoRa
     Serial.println("I'm a lora device!");
-    cbor_encode_int(&mapEncoder, _position);
+    int completePosition = getPostionByAttributeName(attributeName) * 256;
+    completePosition += _position; 
+    cbor_encode_int(&mapEncoder, completePosition);
   #else
     Serial.println("I'm NOT a lora device!");
     String completeName = _name;

--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -152,14 +152,18 @@ void ArduinoCloudProperty::appendAttributeReal(String value, String attributeNam
 
 void ArduinoCloudProperty::appendAttributeName(String attributeName, std::function<void (CborEncoder& mapEncoder)>appendValue, CborEncoder *encoder) {
   if (attributeName != "") {
+    // when the attribute name string is not empty, the attribute identifier is incremented in order to be encoded in the message if the _lightPayload flag is set
     _attributeIdentifier++;
   }
   CborEncoder mapEncoder;
   cbor_encoder_create_map(encoder, &mapEncoder, 2);
   cbor_encode_int(&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));
 
+  // if _lightPayload is true, the property and attribute identifiers will be encoded instead of the property name
   if (_lightPayload) {
+    // the most significant byte of the identifier to be encoded represent the property identifier
     int completeIdentifier = _attributeIdentifier * 256;
+    // the least significant byte of the identifier to be encoded represent the attribute identifier
     completeIdentifier += _identifier;
     cbor_encode_int(&mapEncoder, completeIdentifier);
   } else {
@@ -211,12 +215,14 @@ void ArduinoCloudProperty::setAttributeReal(String attributeName, std::function<
     CborMapData *map = _map_data_list->get(i);
     if (map != nullptr) {
       if (map->light_payload.isSet() && map->light_payload.get()) {
+        // if a light payload is detected, the attribute identifier is retrieved from the cbor map and the corresponding attribute is updated
         int attid = map->attribute_identifier.get();
         if (attid == _attributeIdentifier) {
           setValue(map);
           break;
         }
       } else {
+        // if a normal payload is detected, the name of the attribute to be updated is extracted directly from the cbor map
         String an = map->attribute_name.get();
         if (an == attributeName) {
           setValue(map);

--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -42,10 +42,10 @@ ArduinoCloudProperty::ArduinoCloudProperty()
       _update_interval_millis(0),
       _last_local_change_timestamp(0),
       _last_cloud_change_timestamp(0),
+      _map_data_list(nullptr),
       _identifier(0),
-      _lightPayload(false),
       _attributeIdentifier(0),
-      _map_data_list(nullptr) {
+      _lightPayload(false) {
 }
 
 /******************************************************************************

--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -23,7 +23,7 @@
 #endif
 
 static unsigned long getTimestamp() {
-    return 0;
+  return 0;
 }
 
 /******************************************************************************
@@ -151,16 +151,16 @@ void ArduinoCloudProperty::appendAttributeReal(String value, String attributeNam
 }
 
 void ArduinoCloudProperty::appendAttributeName(String attributeName, std::function<void (CborEncoder& mapEncoder)>appendValue, CborEncoder *encoder) {
-  if(attributeName != ""){
+  if (attributeName != "") {
     _attributeIdentifier++;
   }
   CborEncoder mapEncoder;
   cbor_encoder_create_map(encoder, &mapEncoder, 2);
   cbor_encode_int(&mapEncoder, static_cast<int>(CborIntegerMapKey::Name));
 
-  if(_lightPayload) {
+  if (_lightPayload) {
     int completeIdentifier = _attributeIdentifier * 256;
-    completeIdentifier += _identifier; 
+    completeIdentifier += _identifier;
     cbor_encode_int(&mapEncoder, completeIdentifier);
   } else {
     String completeName = _name;
@@ -204,13 +204,13 @@ void ArduinoCloudProperty::setAttributeReal(String& value, String attributeName)
 }
 
 void ArduinoCloudProperty::setAttributeReal(String attributeName, std::function<void (CborMapData *md)>setValue) {
-  if(attributeName != ""){
+  if (attributeName != "") {
     _attributeIdentifier++;
   }
   for (int i = 0; i < _map_data_list->size(); i++) {
     CborMapData *map = _map_data_list->get(i);
     if (map != nullptr) {
-      if(map->light_payload.isSet() && map->light_payload.get()) {
+      if (map->light_payload.isSet() && map->light_payload.get()) {
         int attid = map->attribute_identifier.get();
         if (attid == _attributeIdentifier) {
           setValue(map);
@@ -225,7 +225,7 @@ void ArduinoCloudProperty::setAttributeReal(String attributeName, std::function<
       }
     }
   }
-   
+
 }
 
 String ArduinoCloudProperty::getAttributeName(String propertyName, char separator) {

--- a/src/ArduinoCloudProperty.h
+++ b/src/ArduinoCloudProperty.h
@@ -98,8 +98,11 @@ class CborMapData {
     MapEntry<String> base_name;
     MapEntry<double> base_time;
     MapEntry<String> name;
+    MapEntry<int>    name_identifier;
+    MapEntry<bool>   light_payload;
     MapEntry<String> attribute_name;
-    MapEntry<int>    property_position;
+    MapEntry<int>    attribute_identifier;
+    MapEntry<int>    property_identifier;
     MapEntry<float>  val;
     MapEntry<String> str_val;
     MapEntry<bool>   bool_val;
@@ -139,8 +142,8 @@ class ArduinoCloudProperty {
     inline String name() const {
       return _name;
     }
-    inline int position() const {
-      return _position;
+    inline int identifier() const {
+      return _identifier;
     }
     inline bool   isReadableByCloud() const {
       return (_permission == Permission::Read) || (_permission == Permission::ReadWrite);
@@ -156,10 +159,10 @@ class ArduinoCloudProperty {
     void setLastLocalChangeTimestamp(unsigned long localChangeTime);
     unsigned long getLastCloudChangeTimestamp();
     unsigned long getLastLocalChangeTimestamp();
-    void setPosition(int pos);
+    void setIdentifier(int identifier);
 
     void updateLocalTimestamp();
-    void append(CborEncoder * encoder);
+    void append(CborEncoder * encoder, bool lightPayload);
     void appendAttributeReal(bool value, String attributeName = "", CborEncoder *encoder = nullptr);
     void appendAttributeReal(int value, String attributeName = "", CborEncoder *encoder = nullptr);
     void appendAttributeReal(float value, String attributeName = "", CborEncoder *encoder = nullptr);
@@ -178,12 +181,6 @@ class ArduinoCloudProperty {
     virtual void fromLocalToCloud() = 0;
     virtual void appendAttributesToCloudReal(CborEncoder *encoder) = 0;
     virtual void setAttributesFromCloud() = 0;
-    virtual String getAttributeNameByPosition(int position) {
-      return "";
-    };
-    virtual int getPostionByAttributeName(String attributeName) {
-      return 0;
-    };
     virtual bool isPrimitive() {
       return false;
     };
@@ -208,8 +205,11 @@ class ArduinoCloudProperty {
     unsigned long      _last_local_change_timestamp;
     unsigned long      _last_cloud_change_timestamp;
     LinkedList<CborMapData *> * _map_data_list;
-    /* Store the position of the property in the array list */
-    int                _position;
+    /* Store the identifier of the property in the array list */
+    int                _identifier;
+    int                _attributeIdentifier;
+    /* Indicates if the property shall be encoded using the identifier instead of the name */
+    bool               _lightPayload;
 };
 
 /******************************************************************************

--- a/src/ArduinoCloudProperty.h
+++ b/src/ArduinoCloudProperty.h
@@ -99,6 +99,7 @@ class CborMapData {
     MapEntry<double> base_time;
     MapEntry<String> name;
     MapEntry<String> attribute_name;
+    MapEntry<int>    property_position;
     MapEntry<float>  val;
     MapEntry<String> str_val;
     MapEntry<bool>   bool_val;
@@ -138,6 +139,9 @@ class ArduinoCloudProperty {
     inline String name() const {
       return _name;
     }
+    inline int position() const {
+      return _position;
+    }
     inline bool   isReadableByCloud() const {
       return (_permission == Permission::Read) || (_permission == Permission::ReadWrite);
     }
@@ -152,6 +156,7 @@ class ArduinoCloudProperty {
     void setLastLocalChangeTimestamp(unsigned long localChangeTime);
     unsigned long getLastCloudChangeTimestamp();
     unsigned long getLastLocalChangeTimestamp();
+    void setPosition(int pos);
 
     void updateLocalTimestamp();
     void append(CborEncoder * encoder);
@@ -173,6 +178,9 @@ class ArduinoCloudProperty {
     virtual void fromLocalToCloud() = 0;
     virtual void appendAttributesToCloudReal(CborEncoder *encoder) = 0;
     virtual void setAttributesFromCloud() = 0;
+    virtual String getAttributeNameByPosition(int position) {
+      return "";
+    };
     virtual bool isPrimitive() {
       return false;
     };
@@ -197,6 +205,8 @@ class ArduinoCloudProperty {
     unsigned long      _last_local_change_timestamp;
     unsigned long      _last_cloud_change_timestamp;
     LinkedList<CborMapData *> * _map_data_list;
+    /* Store the position of the property in the array list */
+    int                _position;
 };
 
 /******************************************************************************

--- a/src/ArduinoCloudProperty.h
+++ b/src/ArduinoCloudProperty.h
@@ -181,6 +181,9 @@ class ArduinoCloudProperty {
     virtual String getAttributeNameByPosition(int position) {
       return "";
     };
+    virtual int getPostionByAttributeName(String attributeName) {
+      return 0;
+    };
     virtual bool isPrimitive() {
       return false;
     };

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -98,7 +98,7 @@ ArduinoCloudProperty& ArduinoCloudThing::addPropertyReal(ArduinoCloudProperty & 
     addProperty(&property, propertyIdentifier);
     return (property);
   }
-  
+
 }
 
 void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const length, bool isSyncMessage) {
@@ -346,12 +346,12 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * val
     int val = 0;
     if (cbor_value_get_int(value_iter, &val) == CborNoError) {
       map_data->light_payload.set(true);
-      map_data->name_identifier.set(val&255);
-      map_data->attribute_identifier.set(val>>8);
+      map_data->name_identifier.set(val & 255);
+      map_data->attribute_identifier.set(val >> 8);
       map_data->light_payload.set(true);
       String name = getPropertyNameByIdentifier(val);
       map_data->name.set(name);
-      
+
 
       if (cbor_value_advance(value_iter) == CborNoError) {
         next_state = MapParserState::MapKey;
@@ -359,7 +359,7 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * val
     }
   }
 
-  
+
 
   return next_state;
 }
@@ -497,7 +497,7 @@ void ArduinoCloudThing::updateProperty(String propertyName, unsigned long cloudC
 // retrieve the property name by the identifier
 String ArduinoCloudThing::getPropertyNameByIdentifier(int propertyIdentifier) {
   ArduinoCloudProperty* property;
-  if(propertyIdentifier>255) {
+  if (propertyIdentifier > 255) {
     property = getProperty(propertyIdentifier & 255);
   } else {
     property = getProperty(propertyIdentifier);

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -328,6 +328,7 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * val
   MapParserState next_state = MapParserState::Error;
 
   if (cbor_value_is_text_string(value_iter)) {
+    // if the value in the cbor message is a string, it corresponds to the name of the property to be updated (int the form [property_name]:[attribute_name])
     char * val      = nullptr;
     size_t val_size = 0;
     if (cbor_value_dup_text_string(value_iter, &val, &val_size, value_iter) == CborNoError) {
@@ -343,6 +344,7 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * val
       next_state = MapParserState::MapKey;
     }
   } else if (cbor_value_is_integer(value_iter)) {
+    // if the value in the cbor message is an integer, a light payload has been used and an integer identifier should be decode in order to retrieve the corresponding property and attribute name to be updated
     int val = 0;
     if (cbor_value_get_int(value_iter, &val) == CborNoError) {
       map_data->light_payload.set(true);

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -86,7 +86,7 @@ int ArduinoCloudThing::encode(uint8_t * data, size_t const size, bool lightPaylo
   return bytes_encoded;
 }
 
-ArduinoCloudProperty& ArduinoCloudThing::addPropertyReal(ArduinoCloudProperty & property, String const & name, Permission const permission) {
+ArduinoCloudProperty& ArduinoCloudThing::addPropertyReal(ArduinoCloudProperty & property, String const & name, Permission const permission, int propertyIdentifier) {
   property.init(name, permission);
   if (isPropertyInContainer(name)) {
     return (*getProperty(name));
@@ -95,7 +95,7 @@ ArduinoCloudProperty& ArduinoCloudThing::addPropertyReal(ArduinoCloudProperty & 
       _numPrimitivesProperties++;
     }
     _numProperties++;
-    addProperty(&property);
+    addProperty(&property, propertyIdentifier);
     return (property);
   }
   

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -357,7 +357,7 @@ ArduinoCloudThing::MapParserState ArduinoCloudThing::handle_Name(CborValue * val
         attribute_name = name.substring(colonPos + 1);
       }
       Serial.print("Name of the attribute: ");
-      Serial.println(name);
+      Serial.println(attribute_name);
       map_data->attribute_name.set(attribute_name);
 
       if (cbor_value_advance(value_iter) == CborNoError) {

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -89,11 +89,13 @@ class ArduinoCloudThing {
     int appendChangedProperties(CborEncoder * arrayEncoder);
     void updateTimestampOnLocallyChangedProperties();
     void updateProperty(String propertyName, unsigned long cloudChangeEventTime);
+    String getPropertyNameByPosition(int propertyPosition);
 
   private:
     LinkedList<ArduinoCloudProperty *>   _property_list;
     /* Keep track of the number of primitive properties in the Thing. If 0 it allows the early exit in updateTimestampOnLocallyChangedProperties() */
     int                                  _numPrimitivesProperties;
+    int                                  _numProperties;
     /* Indicates the if the message received to be decoded is a response to the getLastValues inquiry */
     bool                                 _isSyncMessage;
     /* List of map data that will hold all the attributes of a property */
@@ -135,11 +137,13 @@ class ArduinoCloudThing {
 
     static bool   ifNumericConvertToDouble(CborValue * value_iter, double * numeric_val);
     static double convertCborHalfFloatToDouble(uint16_t const half_val);
-    void freeMapDataList(LinkedList<CborMapData *> *map_data_list);
+    void freeMapDataList(LinkedList<CborMapData *> * map_data_list);
     inline void addProperty(ArduinoCloudProperty   * property_obj) {
+      property_obj->setPosition(_numProperties);
       _property_list.add(property_obj);
     }
     ArduinoCloudProperty * getProperty(String const & name);
+    ArduinoCloudProperty * getProperty(int const & position);
 
 };
 

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -78,7 +78,7 @@ class ArduinoCloudThing {
 
     void begin();
 
-    ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission, int propertyIdentifier);
+    ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission, int propertyIdentifier = -1);
 
     /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
     int encode(uint8_t * data, size_t const size, bool lightPayload = false);
@@ -139,7 +139,7 @@ class ArduinoCloudThing {
     static double convertCborHalfFloatToDouble(uint16_t const half_val);
     void freeMapDataList(LinkedList<CborMapData *> * map_data_list);
     inline void addProperty(ArduinoCloudProperty   * property_obj, int propertyIdentifier) {
-      if(propertyIdentifier != -1) {
+      if (propertyIdentifier != -1) {
         property_obj->setIdentifier(propertyIdentifier);
       } else {
         property_obj->setIdentifier(_numProperties);

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -81,15 +81,15 @@ class ArduinoCloudThing {
     ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission);
 
     /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
-    int encode(uint8_t * data, size_t const size);
+    int encode(uint8_t * data, size_t const size, bool lightPayload = false);
     /* decode a CBOR payload received from the cloud */
     void decode(uint8_t const * const payload, size_t const length, bool isSyncMessage = false);
 
     bool isPropertyInContainer(String const & name);
-    int appendChangedProperties(CborEncoder * arrayEncoder);
+    int appendChangedProperties(CborEncoder * arrayEncoder, bool lightPayload);
     void updateTimestampOnLocallyChangedProperties();
     void updateProperty(String propertyName, unsigned long cloudChangeEventTime);
-    String getPropertyNameByPosition(int propertyPosition);
+    String getPropertyNameByIdentifier(int propertyIdentifier);
 
   private:
     LinkedList<ArduinoCloudProperty *>   _property_list;
@@ -139,11 +139,11 @@ class ArduinoCloudThing {
     static double convertCborHalfFloatToDouble(uint16_t const half_val);
     void freeMapDataList(LinkedList<CborMapData *> * map_data_list);
     inline void addProperty(ArduinoCloudProperty   * property_obj) {
-      property_obj->setPosition(_numProperties);
+      property_obj->setIdentifier(_numProperties);
       _property_list.add(property_obj);
     }
     ArduinoCloudProperty * getProperty(String const & name);
-    ArduinoCloudProperty * getProperty(int const & position);
+    ArduinoCloudProperty * getProperty(int const & identifier);
 
 };
 

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -77,10 +77,11 @@ class ArduinoCloudThing {
     ArduinoCloudThing();
 
     void begin();
-
+    //if propertyIdentifier is different from -1, an integer identifier is associated to the added property to be use instead of the property name when the parameter lightPayload is true in the encode method
     ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission, int propertyIdentifier = -1);
 
     /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
+    /* if lightPayload is true the integer identifier of the property will be encoded in the message instead of the property name in order to reduce the size of the message payload*/
     int encode(uint8_t * data, size_t const size, bool lightPayload = false);
     /* decode a CBOR payload received from the cloud */
     void decode(uint8_t const * const payload, size_t const length, bool isSyncMessage = false);
@@ -142,6 +143,7 @@ class ArduinoCloudThing {
       if (propertyIdentifier != -1) {
         property_obj->setIdentifier(propertyIdentifier);
       } else {
+        // if property identifier is -1, an incremental value will be assigned as identifier.
         property_obj->setIdentifier(_numProperties);
       }
       _property_list.add(property_obj);

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -78,7 +78,7 @@ class ArduinoCloudThing {
 
     void begin();
 
-    ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission);
+    ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission, int propertyIdentifier);
 
     /* encode return > 0 if a property has changed and encodes the changed properties in CBOR format into the provided buffer */
     int encode(uint8_t * data, size_t const size, bool lightPayload = false);
@@ -138,8 +138,12 @@ class ArduinoCloudThing {
     static bool   ifNumericConvertToDouble(CborValue * value_iter, double * numeric_val);
     static double convertCborHalfFloatToDouble(uint16_t const half_val);
     void freeMapDataList(LinkedList<CborMapData *> * map_data_list);
-    inline void addProperty(ArduinoCloudProperty   * property_obj) {
-      property_obj->setIdentifier(_numProperties);
+    inline void addProperty(ArduinoCloudProperty   * property_obj, int propertyIdentifier) {
+      if(propertyIdentifier != -1) {
+        property_obj->setIdentifier(propertyIdentifier);
+      } else {
+        property_obj->setIdentifier(_numProperties);
+      }
       _property_list.add(property_obj);
     }
     ArduinoCloudProperty * getProperty(String const & name);

--- a/src/types/CloudColor.h
+++ b/src/types/CloudColor.h
@@ -198,6 +198,17 @@ class CloudColor : public ArduinoCloudProperty {
       setAttribute(_cloud_value.sat);
       setAttribute(_cloud_value.bri);
     }
+    virtual String getAttributeNameByPosition(int position) {
+      if(position == 1) {
+        return "hue";
+      } else if (position == 2) {
+        return "sat";
+      } else if (position == 3) {
+        return "bri";
+      } else {
+        return "";
+      }
+    };
 };
 
 #endif /* CLOUDCOLOR_H_ */

--- a/src/types/CloudColor.h
+++ b/src/types/CloudColor.h
@@ -198,17 +198,6 @@ class CloudColor : public ArduinoCloudProperty {
       setAttribute(_cloud_value.sat);
       setAttribute(_cloud_value.bri);
     }
-    virtual String getAttributeNameByPosition(int position) {
-      if(position == 1) {
-        return "hue";
-      } else if (position == 2) {
-        return "sat";
-      } else if (position == 3) {
-        return "bri";
-      } else {
-        return "";
-      }
-    };
 };
 
 #endif /* CLOUDCOLOR_H_ */

--- a/src/types/CloudLocation.h
+++ b/src/types/CloudLocation.h
@@ -83,7 +83,6 @@ class CloudLocation : public ArduinoCloudProperty {
       return _value;
     }
 
-
     virtual void fromCloudToLocal() {
       _value = _cloud_value;
     }
@@ -98,24 +97,6 @@ class CloudLocation : public ArduinoCloudProperty {
       setAttribute(_cloud_value.lat);
       setAttribute(_cloud_value.lon);
     }
-    virtual String getAttributeNameByPosition(int position) {
-      if(position == 1) {
-        return "lat";
-      } else if (position == 2) {
-        return "lon";
-      } else {
-        return "";
-      }
-    };
-    virtual int getPostionByAttributeName(String attributeName) {
-      if(attributeName == "lat") {
-        return 1;
-      } else if (attributeName == "lon") {
-        return 2;
-      } else {
-        return 0;
-      }
-    };
 };
 
 #endif /* CLOUDLOCATION_H_ */

--- a/src/types/CloudLocation.h
+++ b/src/types/CloudLocation.h
@@ -107,6 +107,15 @@ class CloudLocation : public ArduinoCloudProperty {
         return "";
       }
     };
+    virtual int getPostionByAttributeName(String attributeName) {
+      if(attributeName == "lat") {
+        return 1;
+      } else if (attributeName == "lon") {
+        return 2;
+      } else {
+        return 0;
+      }
+    };
 };
 
 #endif /* CLOUDLOCATION_H_ */

--- a/src/types/CloudLocation.h
+++ b/src/types/CloudLocation.h
@@ -98,6 +98,15 @@ class CloudLocation : public ArduinoCloudProperty {
       setAttribute(_cloud_value.lat);
       setAttribute(_cloud_value.lon);
     }
+    virtual String getAttributeNameByPosition(int position) {
+      if(position == 1) {
+        return "lat";
+      } else if (position == 2) {
+        return "lon";
+      } else {
+        return "";
+      }
+    };
 };
 
 #endif /* CLOUDLOCATION_H_ */

--- a/test/include/TestUtil.h
+++ b/test/include/TestUtil.h
@@ -17,7 +17,7 @@
    PROTOTYPES
  **************************************************************************************/
 
-std::vector<uint8_t> encode(ArduinoCloudThing & thing);
+std::vector<uint8_t> encode(ArduinoCloudThing & thing, bool lightPayload = false);
 void print(std::vector<uint8_t> const & vect);
 
 #endif /* INCLUDE_TESTUTIL_H_ */

--- a/test/src/TestUtil.cpp
+++ b/test/src/TestUtil.cpp
@@ -15,9 +15,9 @@
    PUBLIC FUNCTIONS
  **************************************************************************************/
 
-std::vector<uint8_t> encode(ArduinoCloudThing & thing) {
+std::vector<uint8_t> encode(ArduinoCloudThing & thing, bool lightPayload) {
   uint8_t buf[200] = {0};
-  int const bytes_buf = thing.encode(buf, 200);
+  int const bytes_buf = thing.encode(buf, 200, lightPayload);
   if (bytes_buf == -1) {
     return std::vector<uint8_t>();
   } else {

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -56,9 +56,9 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
       thing.begin();
 
       CloudBool test = true;
-      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+      thing.addPropertyReal(test, "test", Permission::ReadWrite, 1);
 
-      /* [{0: "test", 4: false}] = 81 A2 00 01 04 F4 */
+      /* [{0: 1, 4: false}] = 81 A2 00 01 04 F4 */
       uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x01, 0x04, 0xF4};
       int const payload_length = sizeof(payload) / sizeof(uint8_t);
       thing.decode(payload, payload_length);
@@ -192,9 +192,9 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
 
       CloudColor color_test = CloudColor(0.0, 0.0, 0.0);
 
-      thing.addPropertyReal(color_test, "test", Permission::ReadWrite);
+      thing.addPropertyReal(color_test, "test", Permission::ReadWrite, 1);
 
-      /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 83 A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 */
+      /* [{0: 257, 2: 2.0},{0: 513, 2: 2.0},{0: 769, 2: 2.0}] = 83 A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 */
       uint8_t const payload[] = {0x83, 0xA2, 0x00, 0x19, 0x01, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x02, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x03, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00 };
       thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -50,6 +50,25 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
 
   /************************************************************************************/
 
+  WHEN("A boolean property is changed via CBOR message - light payload") {
+    GIVEN("CloudProtocol::V2") {
+      ArduinoCloudThing thing;
+      thing.begin();
+
+      CloudBool test = true;
+      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+
+      /* [{0: "test", 4: false}] = 81 A2 00 01 04 F4 */
+      uint8_t const payload[] = {0x81, 0xA2, 0x00, 0x01, 0x04, 0xF4};
+      int const payload_length = sizeof(payload) / sizeof(uint8_t);
+      thing.decode(payload, payload_length);
+
+      REQUIRE(test == false);
+    }
+  }
+
+  /************************************************************************************/
+
   WHEN("A int property is changed via CBOR message") {
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
@@ -152,6 +171,31 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
 
       /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 83 A2 00 68 74 65 73 74 3A 68 75 65 02 FA 40 00 00 00 A2 00 68 74 65 73 74 3A 73 61 74 02 FA 40 00 00 00 A2 00 68 74 65 73 74 3A 62 72 69 02 FA 40 00 00 00 */
       uint8_t const payload[] = {0x83, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x68, 0x75, 0x65, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x73, 0x61, 0x74, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x62, 0x72, 0x69, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00 };
+      thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
+
+      Color color_compare = Color(2.0, 2.0, 2.0);
+      Color value_color_test = color_test.getValue();
+      bool verify = (value_color_test == color_compare);
+      REQUIRE(verify);
+      REQUIRE(value_color_test.hue == color_compare.hue);
+      REQUIRE(value_color_test.sat == color_compare.sat);
+      REQUIRE(value_color_test.bri == color_compare.bri);
+    }
+  }
+
+    /************************************************************************************/
+
+  WHEN("A Color property is changed via CBOR message - light payload") {
+    GIVEN("CloudProtocol::V2") {
+      ArduinoCloudThing thing;
+      thing.begin();
+
+      CloudColor color_test = CloudColor(0.0, 0.0, 0.0);
+
+      thing.addPropertyReal(color_test, "test", Permission::ReadWrite);
+
+      /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 83 A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 */
+      uint8_t const payload[] = {0x83, 0xA2, 0x00, 0x19, 0x01, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x02, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x03, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00 };
       thing.decode(payload, sizeof(payload) / sizeof(uint8_t));
 
       Color color_compare = Color(2.0, 2.0, 2.0);

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -51,11 +51,13 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
   /************************************************************************************/
 
   WHEN("A boolean property is changed via CBOR message - light payload") {
+    /*An integer identifier has been encoded instead of the name of the property in order to have a shorter payload*/
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
       CloudBool test = true;
+      /*The property is added with identifier 1 that will be used instead of the string "test" as property identifier*/
       thing.addPropertyReal(test, "test", Permission::ReadWrite, 1);
 
       /* [{0: 1, 4: false}] = 81 A2 00 01 04 F4 */
@@ -186,12 +188,14 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
   /************************************************************************************/
 
   WHEN("A Color property is changed via CBOR message - light payload") {
+    /*An integer identifier has been encoded instead of the name of the property in order to have a shorter payload*/
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
 
       CloudColor color_test = CloudColor(0.0, 0.0, 0.0);
 
+      /*The property is added with identifier 1 that will be used instead of the string "test" as property identifier*/
       thing.addPropertyReal(color_test, "test", Permission::ReadWrite, 1);
 
       /* [{0: 257, 2: 2.0},{0: 513, 2: 2.0},{0: 769, 2: 2.0}] = 83 A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 */

--- a/test/src/test_decode.cpp
+++ b/test/src/test_decode.cpp
@@ -183,7 +183,7 @@ SCENARIO("Arduino Cloud Properties are decoded", "[ArduinoCloudThing::decode]") 
     }
   }
 
-    /************************************************************************************/
+  /************************************************************************************/
 
   WHEN("A Color property is changed via CBOR message - light payload") {
     GIVEN("CloudProtocol::V2") {

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -47,9 +47,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
       encode(thing);
 
       CloudBool test = true;
-      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+      thing.addPropertyReal(test, "test", Permission::ReadWrite, 1);
 
-      /* [{0: "test", 4: true}] = 9F A2 00 01 04 F5 FF*/
+      /* [{0: 1, 4: true}] = 9F A2 00 01 04 F5 FF*/
       std::vector<uint8_t> const expected = {0x9F, 0xA2, 0x00, 0x01, 0x04, 0xF5, 0xFF};
       std::vector<uint8_t> const actual = encode(thing, true);
       REQUIRE(actual == expected);
@@ -156,9 +156,9 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
       encode(thing);
 
       CloudColor color_test = CloudColor(2.0, 2.0, 2.0);
-      thing.addPropertyReal(color_test, "test", Permission::ReadWrite);
+      thing.addPropertyReal(color_test, "test", Permission::ReadWrite, 1);
 
-      /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 9F A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 FF*/
+      /* [{0: 257, 2: 2.0},{0: 513, 2: 2.0},{0: 769, 2: 2.0}] = 9F A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 FF*/
       std::vector<uint8_t> const expected = {0x9F, 0xA2, 0x00, 0x19, 0x01, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x02, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x03, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xFF };
       std::vector<uint8_t> const actual = encode(thing, true);
       REQUIRE(actual == expected);

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -40,6 +40,24 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
 
   /************************************************************************************/
 
+  WHEN("A 'bool' property is added - light payload") {
+    GIVEN("CloudProtocol::V2") {
+      ArduinoCloudThing thing;
+      thing.begin();
+      encode(thing);
+
+      CloudBool test = true;
+      thing.addPropertyReal(test, "test", Permission::ReadWrite);
+
+      /* [{0: "test", 4: true}] = 9F A2 00 01 04 F5 FF*/
+      std::vector<uint8_t> const expected = {0x9F, 0xA2, 0x00, 0x01, 0x04, 0xF5, 0xFF};
+      std::vector<uint8_t> const actual = encode(thing, true);
+      REQUIRE(actual == expected);
+    }
+  }
+
+  /************************************************************************************/
+
   WHEN("A 'int' property is added") {
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
@@ -125,6 +143,24 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
       /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 9F A2 00 68 74 65 73 74 3A 68 75 65 02 FA 40 00 00 00 A2 00 68 74 65 73 74 3A 73 61 74 02 FA 40 00 00 00 A2 00 68 74 65 73 74 3A 62 72 69 02 FA 40 00 00 00 FF*/
       std::vector<uint8_t> const expected = {0x9F, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x68, 0x75, 0x65, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x73, 0x61, 0x74, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x68, 0x74, 0x65, 0x73, 0x74, 0x3A, 0x62, 0x72, 0x69, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xFF };
       std::vector<uint8_t> const actual = encode(thing);
+      REQUIRE(actual == expected);
+    }
+  }
+
+  /************************************************************************************/
+
+  WHEN("A 'Color' property is added - light payload") {
+    GIVEN("CloudProtocol::V2") {
+      ArduinoCloudThing thing;
+      thing.begin();
+      encode(thing);
+
+      CloudColor color_test = CloudColor(2.0, 2.0, 2.0);
+      thing.addPropertyReal(color_test, "test", Permission::ReadWrite);
+
+      /* [{0: "test:hue", 2: 2.0},{0: "test:sat", 2: 2.0},{0: "test:bri", 2: 2.0}] = 9F A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 FF*/
+      std::vector<uint8_t> const expected = {0x9F, 0xA2, 0x00, 0x19, 0x01, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x02, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xA2, 0x00, 0x19, 0x03, 0x01, 0x02, 0xFA, 0x40, 0x00, 0x00, 0x00, 0xFF };
+      std::vector<uint8_t> const actual = encode(thing, true);
       REQUIRE(actual == expected);
     }
   }

--- a/test/src/test_encode.cpp
+++ b/test/src/test_encode.cpp
@@ -41,12 +41,14 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
   /************************************************************************************/
 
   WHEN("A 'bool' property is added - light payload") {
+    /*An integer identifier must be instead of the name of the property in order to have a shorter payload*/
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
       CloudBool test = true;
+      /*The property is added with identifier 1 that will be used instead of the string "test" as property identifier*/
       thing.addPropertyReal(test, "test", Permission::ReadWrite, 1);
 
       /* [{0: 1, 4: true}] = 9F A2 00 01 04 F5 FF*/
@@ -150,12 +152,14 @@ SCENARIO("Arduino Cloud Properties are encoded", "[ArduinoCloudThing::encode]") 
   /************************************************************************************/
 
   WHEN("A 'Color' property is added - light payload") {
+    /*An integer identifier must be encoded instead of the name of the property in order to have a shorter payload*/
     GIVEN("CloudProtocol::V2") {
       ArduinoCloudThing thing;
       thing.begin();
       encode(thing);
 
       CloudColor color_test = CloudColor(2.0, 2.0, 2.0);
+      /*The property is added with identifier 1 that will be used instead of the string "name" as property identifier */
       thing.addPropertyReal(color_test, "test", Permission::ReadWrite, 1);
 
       /* [{0: 257, 2: 2.0},{0: 513, 2: 2.0},{0: 769, 2: 2.0}] = 9F A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 FF*/


### PR DESCRIPTION
ArduinoCloudThing support for LoRaWAN boards. Due to bandwidth constraints of the LoRA protocol, a variant of the current cbor encoding will be supported with the aim of reducing messages payload when the library is used with an Arduino LoRa board.

Encoding and decoding of cbor messages now support the use of a short property identifier instead of the name of the property in order to reduce the message payload. The assignment of the short identifier must be done explicitly in the `addProperty` method for the boards that need to use light message payloads. 

For simple properties the integer identifier is encoded as an 8-bit integer in the cbor message.

**Example**
```C++
CloudBool test = true;
thing.addPropertyReal(test, "test", Permission::ReadWrite, 1);
/* encode: [{0: 1, 4: true}] = 9F A2 00 01 04 F5 FF */
```

For multi value properties, also every attribute of a property has an integer identifier. The identifier is generated sequentially following the order of invocation of `appendAttributesToCloud()` and `setAttributesFromCloud()`.

For multi value properties the integer identifier is encoded as a 16-bit integer, the MSB encode the attribute identifier, the LSB encode the property identifier (eg: property = 1, attribute = 1  ----> MSB: 0x01 =256, LSB: 0x01 = 1 ------> 256 + 1 = 257)

**Example**
```C++
virtual void appendAttributesToCloud() {
  appendAttribute(_value.hue); //the identifier 1 will be assigned to the attribute "hue"
  appendAttribute(_value.sat); //the identifier 2 will be assigned to the attribute "sat"
  appendAttribute(_value.bri); //the identifier 3 will be assigned to the attribute "bri"
}
virtual void setAttributesFromCloud() {
  setAttribute(_cloud_value.hue); //the identifier 1 will be assigned to the attribute "hue"
  setAttribute(_cloud_value.sat); //the identifier 2 will be assigned to the attribute "sat"
  setAttribute(_cloud_value.bri); //the identifier 3 will be assigned to the attribute "bri"
}

CloudColor color_test = CloudColor(2.0, 2.0, 2.0);
thing.addPropertyReal(color_test, "test", Permission::ReadWrite, 1);
/* encode: [{0: 257, 2: 2.0},{0: 513, 2: 2.0},{0: 769, 2: 2.0}] = 9F A2 00 19 01 01 02 FA 40 00 00 00 A2 00 19 02 01 02 FA 40 00 00 00 A2 00 19 03 01 02 FA 40 00 00 00 FF */    
```

To be used with:
https://github.com/arduino-libraries/Arduino_ConnectionHandler/pull/11
https://github.com/arduino-libraries/ArduinoIoTCloud/pull/83