### PR TITLE
Add setters for CloudTelevision

### DIFF
--- a/src/types/automation/CloudColoredLight.h
+++ b/src/types/automation/CloudColoredLight.h
@@ -82,6 +82,7 @@ class CloudColoredLight : public CloudColor {
 
     void setSwitch(bool const swi) {
       _value.swi = swi;
+      updateLocalTimestamp();
     }
 
     float getHue() {
@@ -90,6 +91,7 @@ class CloudColoredLight : public CloudColor {
 
     void setHue(float const hue) {
       _value.hue = hue;
+      updateLocalTimestamp();
     }
 
     float getSaturation() {
@@ -98,6 +100,7 @@ class CloudColoredLight : public CloudColor {
 
     void setSaturation(float const sat) {
       _value.sat = sat;
+      updateLocalTimestamp();
     }
 
     float getBrightness() {
@@ -106,6 +109,7 @@ class CloudColoredLight : public CloudColor {
 
     void setBrightness(float const bri) {
       _value.bri = bri;
+      updateLocalTimestamp();
     }
 
     virtual void fromCloudToLocal() {

--- a/src/types/automation/CloudTelevision.h
+++ b/src/types/automation/CloudTelevision.h
@@ -168,12 +168,27 @@ class CloudTelevision : public ArduinoCloudProperty {
       return _value;
     }
 
+    void setSwitch(bool const swi) {
+      _value.swi = swi;
+      updateLocalTimestamp();
+    }
+
     bool getSwitch() {
       return _value.swi;
     }
 
+    void setSwitch(uint8_t const vol) {
+      _value.vol = vol;
+      updateLocalTimestamp();
+    }
+
     uint8_t getVolume() {
       return _value.vol;
+    }
+
+    void setMute(bool const mut) {
+      _value.mut = mut;
+      updateLocalTimestamp();
     }
 
     bool getMute() {


### PR DESCRIPTION
Receiving value changes on callbacks for this type, we also may need a way to actually set values for some reason. For ex. if `volume` is increased (from cloud UI or Alexa), then I need to set `mute` to 0 on sketch side.