### PR TITLE
Fix CloudTelevision volume setter name

### DIFF
--- a/src/types/automation/CloudTelevision.h
+++ b/src/types/automation/CloudTelevision.h
@@ -177,7 +177,7 @@ class CloudTelevision : public ArduinoCloudProperty {
       return _value.swi;
     }
 
-    void setSwitch(uint8_t const vol) {
+    void setVolume(uint8_t const vol) {
       _value.vol = vol;
       updateLocalTimestamp();
     }


### PR DESCRIPTION
The volume setter function was incorrectly named `setSwitch`.

Originally reported at:
https://forum.arduino.cc/index.php?topic=658549.msg4440735#msg4440735