### PR TITLE
I have made code more accurate and convenient

### DIFF
--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -145,7 +145,7 @@ void ArduinoCloudThing::decode(uint8_t const * const payload, size_t const lengt
       case MapParserState::BooleanValue : next_state = handle_BooleanValue(&value_iter, map_data); break;
       case MapParserState::LeaveMap     : next_state = handle_LeaveMap(&map_iter, &value_iter, map_data); break;
       case MapParserState::Complete     : /* Nothing to do */                                                   break;
-      case MapParserState::Error        : return;                                                               break;
+      case default                      : return;                                                               break;
     }
 
     current_state = next_state;


### PR DESCRIPTION
I have change
MapParserState::Error to default because suppose none of above statement matches tgen automatically default would execute always so,that is why this is more convenient and effective.
Thank you