### PR TITLE
Declaring PUBLISH_INTERVAL_SEC as unsigned long long const

### DIFF
--- a/test/src/test_publishEvery.cpp
+++ b/test/src/test_publishEvery.cpp
@@ -23,7 +23,7 @@ SCENARIO("A Arduino cloud property is published periodically", "[ArduinoCloudThi
     thing.begin();
 
     CloudBool test = true;
-    unsigned long const PUBLISH_INTERVAL_SEC = 1 * SECONDS;
+    unsigned long long const PUBLISH_INTERVAL_SEC = 1 * SECONDS;
 
     thing.addPropertyReal(test, "test", Permission::ReadWrite).publishEvery(PUBLISH_INTERVAL_SEC);
 


### PR DESCRIPTION
By declaring like this we can avoid any malfunctioning of huge value.