### PR TITLE
Adding a function to register a callback function for retrieving a global timestamp

### DIFF
--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -39,6 +39,7 @@ ArduinoCloudProperty::ArduinoCloudProperty()
       _min_delta_property(0.0f),
       _min_time_between_updates_millis(0),
       _permission(Permission::Read),
+      _get_time_func{nullptr},
       _update_callback_func(nullptr),
       _sync_callback_func(nullptr),
       _has_been_updated_once(false),
@@ -56,9 +57,10 @@ ArduinoCloudProperty::ArduinoCloudProperty()
 /******************************************************************************
    PUBLIC MEMBER FUNCTIONS
  ******************************************************************************/
-void ArduinoCloudProperty::init(String const name, Permission const permission) {
+void ArduinoCloudProperty::init(String const name, Permission const permission, GetTimeCallbackFunc func) {
   _name = name;
   _permission = permission;
+  _get_time_func = func;
 }
 
 ArduinoCloudProperty & ArduinoCloudProperty::onUpdate(UpdateCallbackFunc func) {
@@ -259,7 +261,11 @@ String ArduinoCloudProperty::getAttributeName(String propertyName, char separato
 
 void ArduinoCloudProperty::updateLocalTimestamp() {
   if (isReadableByCloud()) {
-    _last_local_change_timestamp = getTimestamp();
+    if (_get_time_func) {
+      _last_local_change_timestamp = _get_time_func();
+    } else {
+      _last_local_change_timestamp = getTimestamp();
+    }
   }
 }
 

--- a/src/ArduinoCloudProperty.h
+++ b/src/ArduinoCloudProperty.h
@@ -122,6 +122,7 @@ enum class UpdatePolicy {
 };
 
 typedef void(*UpdateCallbackFunc)(void);
+typedef unsigned long(*GetTimeCallbackFunc)();
 
 /******************************************************************************
    CLASS DECLARATION
@@ -131,7 +132,7 @@ class ArduinoCloudProperty {
     typedef void(*SyncCallbackFunc)(ArduinoCloudProperty &property);
   public:
     ArduinoCloudProperty();
-    void init(String const name, Permission const permission);
+    void init(String const name, Permission const permission, GetTimeCallbackFunc func);
 
     /* Composable configuration of the ArduinoCloudProperty class */
     ArduinoCloudProperty & onUpdate(UpdateCallbackFunc func);
@@ -192,6 +193,7 @@ class ArduinoCloudProperty {
 
   private:
     Permission         _permission;
+    GetTimeCallbackFunc _get_time_func;
     UpdateCallbackFunc _update_callback_func;
     void (*_sync_callback_func)(ArduinoCloudProperty &property);
 

--- a/src/ArduinoCloudThing.cpp
+++ b/src/ArduinoCloudThing.cpp
@@ -44,6 +44,7 @@ void PrintFreeRam(void) {
  ******************************************************************************/
 
 ArduinoCloudThing::ArduinoCloudThing() :
+  _get_time_func{nullptr},
   _numPrimitivesProperties(0),
   _numProperties(0),
   _isSyncMessage(false),
@@ -57,6 +58,10 @@ ArduinoCloudThing::ArduinoCloudThing() :
  ******************************************************************************/
 
 void ArduinoCloudThing::begin() {
+}
+
+void ArduinoCloudThing::registerGetTimeCallbackFunc(GetTimeCallbackFunc func) {
+  _get_time_func = func;
 }
 
 int ArduinoCloudThing::encode(uint8_t * data, size_t const size, bool lightPayload) {
@@ -87,7 +92,7 @@ int ArduinoCloudThing::encode(uint8_t * data, size_t const size, bool lightPaylo
 }
 
 ArduinoCloudProperty& ArduinoCloudThing::addPropertyReal(ArduinoCloudProperty & property, String const & name, Permission const permission, int propertyIdentifier) {
-  property.init(name, permission);
+  property.init(name, permission, _get_time_func);
   if (isPropertyInContainer(name)) {
     return (*getProperty(name));
   } else {

--- a/src/ArduinoCloudThing.h
+++ b/src/ArduinoCloudThing.h
@@ -77,6 +77,7 @@ class ArduinoCloudThing {
     ArduinoCloudThing();
 
     void begin();
+    void registerGetTimeCallbackFunc(GetTimeCallbackFunc func);
     //if propertyIdentifier is different from -1, an integer identifier is associated to the added property to be use instead of the property name when the parameter lightPayload is true in the encode method
     ArduinoCloudProperty   & addPropertyReal(ArduinoCloudProperty   & property, String const & name, Permission const permission, int propertyIdentifier = -1);
 
@@ -93,6 +94,7 @@ class ArduinoCloudThing {
     String getPropertyNameByIdentifier(int propertyIdentifier);
 
   private:
+    GetTimeCallbackFunc                  _get_time_func;
     LinkedList<ArduinoCloudProperty *>   _property_list;
     /* Keep track of the number of primitive properties in the Thing. If 0 it allows the early exit in updateTimestampOnLocallyChangedProperties() */
     int                                  _numPrimitivesProperties;


### PR DESCRIPTION
This is necessary because right now we are relying on the RTC within the SAMD MCU which is instantiated (RTCZero) within the ArduinoIoTCloud library and reference within ArduinoCloudThing via extern devlaration. Due to the extern binding this is a very brittle dependency which can be easily destroyed, it is therefore better to explicitly register a function which provides the time (this can be serviced by the TimeService class available in ArduinoIoTCloud.

Successfully tested on PROD with

* MKR 1000 :heavy_check_mark:
* MKR WiFi 1010 :heavy_check_mark:
* MKR GSM 1400 :heavy_check_mark:
* ESP8266 :heavy_check_mark: