### PR TITLE
Removal of hidden dependency to RTCZero which is used to retrieve a epoch type timestamp

### DIFF
--- a/src/ArduinoCloudProperty.cpp
+++ b/src/ArduinoCloudProperty.cpp
@@ -17,19 +17,9 @@
 
 #include "ArduinoCloudProperty.h"
 
-#ifdef ARDUINO_ARCH_SAMD
-  #include <RTCZero.h>
-  extern RTCZero rtc;
+#ifndef ARDUINO_ARCH_SAMD
+  #pragma message "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
 #endif
-
-static unsigned long getTimestamp() {
-  #ifdef ARDUINO_ARCH_SAMD
-  return rtc.getEpoch();
-  #else
-#pragma message "No RTC available on this architecture - ArduinoIoTCloud will not keep track of local change timestamps ."
-  return 0;
-  #endif
-}
 
 /******************************************************************************
    CTOR/DTOR
@@ -263,8 +253,6 @@ void ArduinoCloudProperty::updateLocalTimestamp() {
   if (isReadableByCloud()) {
     if (_get_time_func) {
       _last_local_change_timestamp = _get_time_func();
-    } else {
-      _last_local_change_timestamp = getTimestamp();
     }
   }
 }


### PR DESCRIPTION
In https://github.com/arduino-libraries/ArduinoCloudThing/pull/55 the possibility for retrieving a epoch type timestamp via a registered callback function has been introduced, the changes in https://github.com/arduino-libraries/ArduinoIoTCloud/pull/93 register such a function which allows us to to remove the hidden dependency to RTCZero altogether.